### PR TITLE
feat(ui): favorite commanders horizontal carousel

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -120,9 +120,9 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame }: DashboardPag
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Your favorite commanders</h2>
           <div className="mt-2">
             <div className="-mx-3 px-3">
-              <div className="flex gap-3 overflow-x-auto scroll-pl-3 py-2">
+              <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory pl-3 py-2">
                 {topCommanders.map((c) => (
-                  <div key={c.name} className="flex-shrink-0 w-56 scroll-snap-align-start">
+                  <div key={c.name} className="flex-shrink-0 w-56 snap-start">
                     <FavoriteCommanderCard name={c.name} />
                   </div>
                 ))}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -25,8 +25,8 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame }: DashboardPag
 
   const topCommanders = useMemo(() => {
     return [...stats.byCommander]
+      .filter((c) => c.games > 1)
       .sort((a, b) => b.games - a.games)
-      .slice(0, 4)
   }, [stats.byCommander])
 
   // early empty state mirrors StatsPage so users still see a call to action


### PR DESCRIPTION
Turn the favorite commanders section into a horizontally scrollable carousel for easier browsing on small screens.