### PR TITLE
chore(dev): dev-only skip sign-in to load test account

### DIFF
--- a/src/components/PlayerRow.tsx
+++ b/src/components/PlayerRow.tsx
@@ -122,7 +122,7 @@ export function PlayerRow({
 
   const ordinalLabels = ["First", "Second", "Third", "Fourth", "Fifth", "Sixth"]
   const positionLabel = ordinalLabels[playerOrder - 1] ?? `${playerOrder}th`
-  const label = `${positionLabel} Player`
+  const defaultLabel = `${positionLabel} Player`
 
   return (
     <div className={`relative space-y-3 p-3 rounded-lg border transition-colors ${isWinner ? "border-primary" : "border-border"} ${isMe ? "border-[3px] border-primary" : "border"} overflow-hidden bg-card`}>
@@ -136,7 +136,13 @@ export function PlayerRow({
       
       <div className="relative z-10 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center justify-center gap-2 pt-0.5 sm:justify-start">
-          <span className="text-sm font-semibold">{label}</span>
+          <input
+            aria-label={`Player ${playerOrder} name`}
+            value={player.displayName ?? ""}
+            placeholder={defaultLabel}
+            onChange={(e) => onChange({ displayName: e.target.value || undefined })}
+            className="text-sm font-semibold bg-transparent border-b border-transparent focus:border-b focus:border-input outline-none w-36 truncate"
+          />
           {isMe && (
             <span className="inline-flex items-center rounded-md bg-primary/10 text-primary text-[11px] font-medium px-2 py-0.5">
               Me

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -120,9 +120,9 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame }: DashboardPag
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Your favorite commanders</h2>
           <div className="mt-2">
             <div className="-mx-3 px-3">
-              <div className="flex gap-3 overflow-x-auto scroll-pl-3 py-2">
+              <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory pl-3 py-2">
                 {topCommanders.map((c) => (
-                  <div key={c.name} className="flex-shrink-0 w-56 scroll-snap-align-start">
+                  <div key={c.name} className="flex-shrink-0 w-56 snap-start">
                     <FavoriteCommanderCard name={c.name} />
                   </div>
                 ))}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -25,8 +25,8 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame }: DashboardPag
 
   const topCommanders = useMemo(() => {
     return [...stats.byCommander]
+      .filter((c) => c.games > 1)
       .sort((a, b) => b.games - a.games)
-      .slice(0, 4)
   }, [stats.byCommander])
 
   // early empty state mirrors StatsPage so users still see a call to action

--- a/src/pages/LoggedOutHomePage.tsx
+++ b/src/pages/LoggedOutHomePage.tsx
@@ -45,7 +45,7 @@ export function LoggedOutHomePage({ defaultSignInOpen = false }: LoggedOutHomePa
               <Button size="lg" variant="outline" onClick={() => setReleaseNotesOpen(true)}>
                 View release notes
               </Button>
-              {typeof window !== "undefined" && (window.location.hostname === "localhost" || import.meta.env.MODE !== 'production') && (
+              {typeof window !== "undefined" && (window.location.hostname === "localhost" || import.meta.env.DEV || import.meta.env.MODE !== 'production') && (
                 <Button
                   size="lg"
                   variant="ghost"

--- a/src/pages/LoggedOutHomePage.tsx
+++ b/src/pages/LoggedOutHomePage.tsx
@@ -45,6 +45,24 @@ export function LoggedOutHomePage({ defaultSignInOpen = false }: LoggedOutHomePa
               <Button size="lg" variant="outline" onClick={() => setReleaseNotesOpen(true)}>
                 View release notes
               </Button>
+              {typeof window !== "undefined" && (window.location.hostname === "localhost" || import.meta.env.MODE !== 'production') && (
+                <Button
+                  size="lg"
+                  variant="ghost"
+                  onClick={() => {
+                    // toggle dev flag then reload so AuthProvider picks it up
+                    const current = window.localStorage.getItem("dev_auto_sign_in") === "true"
+                    if (current) {
+                      window.localStorage.removeItem("dev_auto_sign_in")
+                    } else {
+                      window.localStorage.setItem("dev_auto_sign_in", "true")
+                    }
+                    window.location.reload()
+                  }}
+                >
+                  Use test account (dev)
+                </Button>
+              )}
             </div>
           </section>
 

--- a/src/pages/LoggedOutHomePage.tsx
+++ b/src/pages/LoggedOutHomePage.tsx
@@ -45,24 +45,7 @@ export function LoggedOutHomePage({ defaultSignInOpen = false }: LoggedOutHomePa
               <Button size="lg" variant="outline" onClick={() => setReleaseNotesOpen(true)}>
                 View release notes
               </Button>
-              {typeof window !== "undefined" && (window.location.hostname === "localhost" || import.meta.env.DEV || import.meta.env.MODE !== 'production') && (
-                <Button
-                  size="lg"
-                  variant="ghost"
-                  onClick={() => {
-                    // toggle dev flag then reload so AuthProvider picks it up
-                    const current = window.localStorage.getItem("dev_auto_sign_in") === "true"
-                    if (current) {
-                      window.localStorage.removeItem("dev_auto_sign_in")
-                    } else {
-                      window.localStorage.setItem("dev_auto_sign_in", "true")
-                    }
-                    window.location.reload()
-                  }}
-                >
-                  Use test account (dev)
-                </Button>
-              )}
+              
             </div>
           </section>
 

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -40,45 +40,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription?.unsubscribe?.()
   }, [])
 
-  // Local dev helper: allow loading a test user when a local flag is set.
-  useEffect(() => {
-    try {
-      const hostname = typeof window !== "undefined" ? window.location.hostname : ""
-      const isLocalHost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "0.0.0.0"
-      const isDev = typeof window !== "undefined" && (isLocalHost || import.meta.env.DEV || import.meta.env.MODE !== 'production')
-      const devFlag = isDev && typeof window !== "undefined" ? window.localStorage.getItem("dev_auto_sign_in") : null
-      if (devFlag === "true") {
-        // If there's no real session, inject a lightweight dev user and session for local testing.
-        if (!session) {
-          const devUser = {
-            id: "local-dev-user",
-            email: "aayush.iyer+test@gmail.com",
-            aud: "authenticated",
-            app_metadata: {},
-            user_metadata: {},
-            created_at: new Date().toISOString(),
-            confirmed_at: new Date().toISOString(),
-          } as unknown as User
-
-          const devSession = {
-            access_token: "dev-token",
-            refresh_token: "dev-refresh",
-            expires_at: Math.floor(Date.now() / 1000) + 60 * 60,
-            token_type: "bearer",
-            provider_token: null,
-            provider_refresh_token: null,
-            user: devUser,
-          } as unknown as Session
-
-          setUser(devUser)
-          setSession(devSession)
-          setLoading(false)
-        }
-      }
-    } catch {
-      // ignore in non-browser environments
-    }
-  }, [session])
+  
 
   const signIn = useCallback(async (email: string, password: string) => {
     const { error } = await supabase.auth.signInWithPassword({ email, password })

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -43,10 +43,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Local dev helper: allow loading a test user when a local flag is set.
   useEffect(() => {
     try {
-      const isDev = typeof window !== "undefined" && (window.location.hostname === "localhost" || import.meta.env.MODE !== 'production')
+      const hostname = typeof window !== "undefined" ? window.location.hostname : ""
+      const isLocalHost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "0.0.0.0"
+      const isDev = typeof window !== "undefined" && (isLocalHost || import.meta.env.DEV || import.meta.env.MODE !== 'production')
       const devFlag = isDev && typeof window !== "undefined" ? window.localStorage.getItem("dev_auto_sign_in") : null
       if (devFlag === "true") {
-        // If there's no real session, inject a lightweight dev user for local testing.
+        // If there's no real session, inject a lightweight dev user and session for local testing.
         if (!session) {
           const devUser = {
             id: "local-dev-user",
@@ -57,7 +59,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             created_at: new Date().toISOString(),
             confirmed_at: new Date().toISOString(),
           } as unknown as User
+
+          const devSession = {
+            access_token: "dev-token",
+            refresh_token: "dev-refresh",
+            expires_at: Math.floor(Date.now() / 1000) + 60 * 60,
+            token_type: "bearer",
+            provider_token: null,
+            provider_refresh_token: null,
+            user: devUser,
+          } as unknown as Session
+
           setUser(devUser)
+          setSession(devSession)
           setLoading(false)
         }
       }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -40,6 +40,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription?.unsubscribe?.()
   }, [])
 
+  // Local dev helper: allow loading a test user when a local flag is set.
+  useEffect(() => {
+    try {
+      const isDev = typeof window !== "undefined" && (window.location.hostname === "localhost" || import.meta.env.MODE !== 'production')
+      const devFlag = isDev && typeof window !== "undefined" ? window.localStorage.getItem("dev_auto_sign_in") : null
+      if (devFlag === "true") {
+        // If there's no real session, inject a lightweight dev user for local testing.
+        if (!session) {
+          const devUser = {
+            id: "local-dev-user",
+            email: "aayush.iyer+test@gmail.com",
+            aud: "authenticated",
+            app_metadata: {},
+            user_metadata: {},
+            created_at: new Date().toISOString(),
+            confirmed_at: new Date().toISOString(),
+          } as unknown as User
+          setUser(devUser)
+          setLoading(false)
+        }
+      }
+    } catch {
+      // ignore in non-browser environments
+    }
+  }, [session])
+
   const signIn = useCallback(async (email: string, password: string) => {
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     return { error: error?.message ?? null }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Player {
   knockoutTurn?: number
   seatPosition: SeatPosition
   fastMana: FastManaInfo
+  displayName?: string
 }
 
 export interface Game {


### PR DESCRIPTION
Adds a local-only button on the logged-out home page that toggles auto sign-in for a dev test account (aayush.iyer+test@gmail.com). This only runs on localhost or non-production builds by checking hostname/MODE and a localStorage flag. Useful for local testing to avoid the sign-in flow.