### PR TITLE
Add live game tracking flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom"
 import { Toaster, toast } from "sonner"
 import { Loader2 } from "lucide-react"
@@ -19,6 +19,7 @@ import { DashboardPage } from "@/pages/DashboardPage"
 import { StatsPage } from "@/pages/StatsPage"
 import { LogGamePage } from "@/pages/LogGamePage"
 import { EditGamePage } from "@/pages/EditGamePage"
+import { LiveGamePage } from "@/pages/LiveGamePage"
 import { HistoryPage } from "@/pages/HistoryPage"
 import { SettingsPage } from "@/pages/SettingsPage"
 import { LoggedOutHomePage } from "@/pages/LoggedOutHomePage"
@@ -26,19 +27,39 @@ import { ReleaseNotesModal } from "@/pages/ReleaseNotesPage"
 import { useGames } from "@/hooks/useGames"
 import { trackGameLogged } from '@/lib/analytics'
 import { useAuth } from "@/hooks/useAuth"
+import { clearLiveGameSession, loadLiveGameSession } from "@/lib/liveGameStorage"
 import type { Game } from "@/types"
 
-type GameFlowMode = "log" | "edit"
+type GameFlowMode = "log" | "edit" | "live"
 
 interface GameFlowState {
   mode: GameFlowMode
   minimized: boolean
   editGameId?: string
   prefillCommander?: string
+  resumeLiveGame?: boolean
 }
 
 type ThemeMode = "light" | "dark" | "system"
 type Theme = "light" | "dark"
+const LOCAL_LIVE_COMPLETED_KEY_PREFIX = "commando_local_live_completed_games:"
+
+function getLocalLiveCompletedKey(userId: string) {
+  return `${LOCAL_LIVE_COMPLETED_KEY_PREFIX}${userId}`
+}
+
+function loadLocalLiveCompletedGames(userId: string): Game[] {
+  try {
+    const raw = localStorage.getItem(getLocalLiveCompletedKey(userId))
+    return raw ? (JSON.parse(raw) as Game[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveLocalLiveCompletedGames(userId: string, games: Game[]): void {
+  localStorage.setItem(getLocalLiveCompletedKey(userId), JSON.stringify(games))
+}
 
 function App() {
   const { user, loading: authLoading, signOut } = useAuth()
@@ -47,19 +68,35 @@ function App() {
   const [gameFlow, setGameFlow] = useState<GameFlowState | null>(null)
   const [isLogGameDirty, setIsLogGameDirty] = useState(false)
   const [showDiscardLogDialog, setShowDiscardLogDialog] = useState(false)
+  const [hasLiveGame, setHasLiveGame] = useState(false)
+  const [localLiveCompletedGames, setLocalLiveCompletedGames] = useState<Game[]>([])
   const [themeMode, setThemeMode] = useState<ThemeMode>("system")
   const [systemTheme, setSystemTheme] = useState<Theme>("light")
   const navigate = useNavigate()
   const location = useLocation()
-  const { games, loading: gamesLoading, addGame, updateGame, deleteGame, getGame, replaceGames, clearGames } = useGames()
+  const { games, loading: gamesLoading, addGame, updateGame, deleteGame, replaceGames, clearGames } = useGames()
+  const displayedGames = useMemo(
+    () => [...localLiveCompletedGames, ...games].sort((a, b) => new Date(b.playedAt).getTime() - new Date(a.playedAt).getTime()),
+    [games, localLiveCompletedGames]
+  )
 
   const resolvedTheme: Theme = themeMode === "system" ? systemTheme : themeMode
 
   const editingGame = gameFlow?.mode === "edit" && gameFlow.editGameId
-    ? getGame(gameFlow.editGameId)
+    ? displayedGames.find((game) => game.id === gameFlow.editGameId)
     : undefined
 
+  function discardInProgressLiveSession() {
+    if (!user?.id) return
+    if (!loadLiveGameSession(user.id)) return
+    clearLiveGameSession(user.id)
+    setHasLiveGame(false)
+    setGameFlow((prev) => (prev?.mode === "live" ? null : prev))
+    toast.message("Discarded in-progress live game.")
+  }
+
   function openLogGameFlow(prefillCommander?: string) {
+    discardInProgressLiveSession()
     setIsLogGameDirty(false)
     setGameFlow({ mode: "log", minimized: false, prefillCommander })
   }
@@ -67,6 +104,17 @@ function App() {
   function openEditGameFlow(id: string) {
     setIsLogGameDirty(false)
     setGameFlow({ mode: "edit", minimized: false, editGameId: id })
+  }
+
+  function openLiveGameFlow(prefillCommander?: string) {
+    discardInProgressLiveSession()
+    setIsLogGameDirty(false)
+    setGameFlow({ mode: "live", minimized: false, prefillCommander })
+  }
+
+  function resumeLiveGameFlow() {
+    setIsLogGameDirty(false)
+    setGameFlow({ mode: "live", minimized: false, resumeLiveGame: true })
   }
 
   function navigateWithFlowMinimize(path: string) {
@@ -83,7 +131,7 @@ function App() {
   }
 
   function closeGameFlow(force = false) {
-    if (!force && gameFlow?.mode === "log" && isLogGameDirty) {
+    if (!force && (gameFlow?.mode === "log" || gameFlow?.mode === "live") && isLogGameDirty) {
       setShowDiscardLogDialog(true)
       return
     }
@@ -118,10 +166,36 @@ function App() {
     })()
   }
 
+  function handleSaveLiveGame(game: Game) {
+    if (!user?.id) {
+      toast.error("Could not save local live game.")
+      return
+    }
+    const localGame: Game = { ...game, isLocalOnly: true }
+    setLocalLiveCompletedGames((prev) => {
+      const next = [localGame, ...prev]
+      saveLocalLiveCompletedGames(user.id, next)
+      return next
+    })
+    try { trackGameLogged(localGame) } catch { void 0 }
+    closeGameFlow(true)
+    toast.success("Live game saved locally.")
+  }
+
   function handleUpdateGame(game: Game) {
     void (async () => {
       try {
-        await updateGame(game.id, game)
+        const isLocalOnly = localLiveCompletedGames.some((entry) => entry.id === game.id)
+        if (isLocalOnly) {
+          if (!user?.id) throw new Error("No user")
+          setLocalLiveCompletedGames((prev) => {
+            const next = prev.map((entry) => (entry.id === game.id ? { ...game, isLocalOnly: true } : entry))
+            saveLocalLiveCompletedGames(user.id, next)
+            return next
+          })
+        } else {
+          await updateGame(game.id, game)
+        }
         setRecentlyEditedGameId(game.id)
         closeGameFlow(true)
         navigate("/history")
@@ -134,6 +208,13 @@ function App() {
 
   function handleCancelGameFlow() {
     closeGameFlow()
+  }
+
+  function handleClearAllGames() {
+    if (!user?.id) return
+    void clearGames()
+    setLocalLiveCompletedGames([])
+    saveLocalLiveCompletedGames(user.id, [])
   }
 
   useEffect(() => {
@@ -175,6 +256,17 @@ function App() {
   }, [])
 
   useEffect(() => {
+    if (!user?.id) {
+      setHasLiveGame(false)
+      setLocalLiveCompletedGames([])
+      return
+    }
+
+    setHasLiveGame(Boolean(loadLiveGameSession(user.id)))
+    setLocalLiveCompletedGames(loadLocalLiveCompletedGames(user.id))
+  }, [user?.id])
+
+  useEffect(() => {
     document.documentElement.classList.toggle("dark", resolvedTheme === "dark")
     localStorage.setItem("theme-mode", themeMode)
   }, [resolvedTheme, themeMode])
@@ -207,6 +299,9 @@ function App() {
         currentPath={location.pathname}
         onNavigate={navigateWithFlowMinimize}
         onOpenLogGame={openLogGameFlow}
+        onOpenLiveGame={openLiveGameFlow}
+        onResumeLiveGame={resumeLiveGameFlow}
+        hasLiveGame={hasLiveGame}
         
         onShowReleaseNotes={() => setShowReleaseNotes(true)}
         userEmail={user.email}
@@ -230,9 +325,12 @@ function App() {
               path="/"
               element={
                 <DashboardPage
-                  games={games}
+                  games={displayedGames}
                   onNavigate={navigateWithFlowMinimize}
                   onOpenLogGame={openLogGameFlow}
+                  onOpenLiveGame={openLiveGameFlow}
+                  onResumeLiveGame={resumeLiveGameFlow}
+                  hasLiveGame={hasLiveGame}
                   onEditGame={openEditGameFlow}
                 />
               }
@@ -241,9 +339,12 @@ function App() {
               path="/stats"
               element={
                 <StatsPage
-                  games={games}
+                  games={displayedGames}
                   onNavigate={navigateWithFlowMinimize}
                   onOpenLogGame={openLogGameFlow}
+                  onOpenLiveGame={openLiveGameFlow}
+                  onResumeLiveGame={resumeLiveGameFlow}
+                  hasLiveGame={hasLiveGame}
                 />
               }
             />
@@ -251,8 +352,17 @@ function App() {
               path="/history"
               element={
                 <HistoryPage
-                  games={games}
+                  games={displayedGames}
                   onDeleteGame={(id) => {
+                    const isLocalOnly = localLiveCompletedGames.some((entry) => entry.id === id)
+                    if (isLocalOnly) {
+                      setLocalLiveCompletedGames((prev) => {
+                        const next = prev.filter((entry) => entry.id !== id)
+                        saveLocalLiveCompletedGames(user.id, next)
+                        return next
+                      })
+                      return
+                    }
                     void deleteGame(id)
                   }}
                   onEditGame={openEditGameFlow}
@@ -263,7 +373,7 @@ function App() {
             />
             <Route
               path="/settings"
-              element={<SettingsPage onImport={replaceGames} onClearAll={clearGames} games={games} />}
+              element={<SettingsPage onImport={replaceGames} onClearAll={handleClearAllGames} games={displayedGames} />}
             />
             {/* Map page removed */}
             <Route path="*" element={<Navigate to="/" replace />} />
@@ -295,7 +405,7 @@ function App() {
 
       {gameFlow && (
         <GameFlowDrawer
-          title={gameFlow.mode === "log" ? "Log Game" : "Edit Game"}
+          title={gameFlow.mode === "log" ? "Log Game" : gameFlow.mode === "edit" ? "Edit Game" : "Live Game"}
           minimized={gameFlow.minimized}
           onMinimize={minimizeGameFlow}
           onRestore={restoreGameFlow}
@@ -303,10 +413,22 @@ function App() {
         >
           {gameFlow.mode === "log" ? (
             <LogGamePage
+              games={displayedGames}
               prefillCommander={gameFlow.prefillCommander}
               onSave={handleSaveGame}
               onCancel={handleCancelGameFlow}
               onDirtyChange={setIsLogGameDirty}
+            />
+          ) : gameFlow.mode === "live" ? (
+            <LiveGamePage
+              games={displayedGames}
+              userId={user.id}
+              initialSession={gameFlow.resumeLiveGame ? loadLiveGameSession(user.id) : null}
+              prefillCommander={gameFlow.prefillCommander}
+              onSave={handleSaveLiveGame}
+              onCancel={handleCancelGameFlow}
+              onDirtyChange={setIsLogGameDirty}
+              onSessionStateChange={setHasLiveGame}
             />
           ) : (
             editingGame && (

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,11 +1,15 @@
 import { LayoutDashboard, ChartSpline, History, Settings, Plus, FileText, Bug, LogOut } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { NewGameMenu } from "@/components/NewGameMenu"
 import { cn } from "@/lib/utils"
 
 interface NavProps {
   currentPath: string
   onNavigate: (path: string) => void
   onOpenLogGame: (commanderName?: string) => void
+  onOpenLiveGame: (commanderName?: string) => void
+  onResumeLiveGame: () => void
+  hasLiveGame?: boolean
   onShowReleaseNotes: () => void
   userEmail?: string
   onSignOut?: () => void
@@ -18,7 +22,7 @@ const NAV_ITEMS: { path: string; label: string; Icon: React.ComponentType<{ clas
   { path: "/settings", label: "Settings", Icon: Settings },
 ]
 
-export function Nav({ currentPath, onNavigate, onOpenLogGame, onShowReleaseNotes, userEmail, onSignOut }: NavProps) {
+export function Nav({ currentPath, onNavigate, onOpenLogGame, onOpenLiveGame, onResumeLiveGame, hasLiveGame = false, onShowReleaseNotes, userEmail, onSignOut }: NavProps) {
   function isActivePath(path: string) {
     if (path === "/") return currentPath === "/"
     return currentPath === path || currentPath.startsWith(`${path}/`)
@@ -102,14 +106,22 @@ export function Nav({ currentPath, onNavigate, onOpenLogGame, onShowReleaseNotes
             ))}
           </div>
           <div>
-            <Button size="sm" className="gap-1.5 w-full sm:w-auto" onClick={() => onOpenLogGame?.()}>
-              <Plus className="h-4 w-4" />
-              <span className="hidden sm:inline">Track a game</span>
-              <span className="sm:hidden">Track Game</span>
-              <kbd className="ml-0.5 text-[10px] font-mono bg-white/15 border border-white/25 px-1 py-0.5 rounded leading-none">
-                N
-              </kbd>
-            </Button>
+            <NewGameMenu
+              hasLiveGame={hasLiveGame}
+              onQuickLog={onOpenLogGame}
+              onStartLiveGame={onOpenLiveGame}
+              onResumeLiveGame={onResumeLiveGame}
+              trigger={
+                <Button size="sm" className="gap-1.5 w-full sm:w-auto">
+                  <Plus className="h-4 w-4" />
+                  <span className="hidden sm:inline">Track a game</span>
+                  <span className="sm:hidden">Track Game</span>
+                  <kbd className="ml-0.5 text-[10px] font-mono bg-white/15 border border-white/25 px-1 py-0.5 rounded leading-none">
+                    N
+                  </kbd>
+                </Button>
+              }
+            />
           </div>
         </div>
       </div>

--- a/src/components/NewGameMenu.tsx
+++ b/src/components/NewGameMenu.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react"
+import { useState } from "react"
+import { RadioTower, Play, PencilLine } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+interface NewGameMenuProps {
+  trigger: ReactNode
+  hasLiveGame?: boolean
+  prefillCommander?: string
+  onQuickLog: (commanderName?: string) => void
+  onStartLiveGame: (commanderName?: string) => void
+  onResumeLiveGame: () => void
+}
+
+export function NewGameMenu({
+  trigger,
+  hasLiveGame = false,
+  prefillCommander,
+  onQuickLog,
+  onStartLiveGame,
+  onResumeLiveGame,
+}: NewGameMenuProps) {
+  const [open, setOpen] = useState(false)
+
+  function runAndClose(action: () => void) {
+    setOpen(false)
+    action()
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent className="w-64 p-2" align="end">
+        <div className="space-y-1">
+          {hasLiveGame && (
+            <Button variant="ghost" className="w-full justify-start gap-2" onClick={() => runAndClose(() => onResumeLiveGame())}>
+              <RadioTower className="h-4 w-4" />
+              Resume live game
+            </Button>
+          )}
+          {!hasLiveGame && (
+            <Button variant="ghost" className="w-full justify-start gap-2" onClick={() => runAndClose(() => onStartLiveGame(prefillCommander))}>
+              <Play className="h-4 w-4" />
+              Start a live game
+            </Button>
+          )}
+          {hasLiveGame && (
+            <Button variant="ghost" className="w-full justify-start gap-2" onClick={() => runAndClose(() => onStartLiveGame(prefillCommander))}>
+              <Play className="h-4 w-4" />
+              Start new live game (discard current)
+            </Button>
+          )}
+          <Button variant="ghost" className="w-full justify-start gap-2" onClick={() => runAndClose(() => onQuickLog(prefillCommander))}>
+            <PencilLine className="h-4 w-4" />
+            {hasLiveGame ? "Log a game (discard live)" : "Log a game"}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/PlayerRow.tsx
+++ b/src/components/PlayerRow.tsx
@@ -39,6 +39,7 @@ interface PlayerRowProps {
   knownPlayerNames?: string[]
   fieldErrors?: FieldErrors
   showWinnerError?: boolean
+  showOutcomeControls?: boolean
 }
 
 export function PlayerRow({
@@ -59,6 +60,7 @@ export function PlayerRow({
   knownPlayerNames,
   fieldErrors,
   showWinnerError,
+  showOutcomeControls = true,
 }: PlayerRowProps) {
   const [showPartner, setShowPartner] = useState(!!player.partnerName)
   const [showSuggestions, setShowSuggestions] = useState(false)
@@ -205,7 +207,8 @@ export function PlayerRow({
           </FormField>
         </div>
 
-        <div className="hidden sm:flex flex-wrap items-center justify-end gap-2 self-end sm:self-auto max-w-full">
+        {showOutcomeControls && (
+          <div className="hidden sm:flex flex-wrap items-center justify-end gap-2 self-end sm:self-auto max-w-full">
           <Button
             type="button"
             variant={isWinner ? "default" : "outline"}
@@ -276,25 +279,28 @@ export function PlayerRow({
               </Button>
             </div>
           )}
-        </div>
+          </div>
+        )}
       </div>
 
       {/* Mobile winner controls */}
-      <div className="flex items-center justify-center gap-2 sm:hidden">
-        <Button
-          type="button"
-          variant={isWinner ? "default" : "outline"}
-          className={`gap-1.5 text-sm h-10 px-3 ${
-            isWinner ? "" : showWinnerError ? "border-destructive text-destructive" : "text-muted-foreground"
-          }`}
-          onClick={onSetWinner}
-        >
-          <Trophy className="h-3 w-3" />
-          Winner
-        </Button>
-      </div>
+      {showOutcomeControls && (
+        <div className="flex items-center justify-center gap-2 sm:hidden">
+          <Button
+            type="button"
+            variant={isWinner ? "default" : "outline"}
+            className={`gap-1.5 text-sm h-10 px-3 ${
+              isWinner ? "" : showWinnerError ? "border-destructive text-destructive" : "text-muted-foreground"
+            }`}
+            onClick={onSetWinner}
+          >
+            <Trophy className="h-3 w-3" />
+            Winner
+          </Button>
+        </div>
+      )}
 
-      {isWinner && (
+      {showOutcomeControls && isWinner && (
         <div className="flex items-center justify-center gap-1 sm:hidden">
           <Button
             type="button"
@@ -326,7 +332,7 @@ export function PlayerRow({
         </div>
       )}
 
-      {!isWinner && showKoTurnControls && (
+      {showOutcomeControls && !isWinner && showKoTurnControls && (
         <div className="flex items-center justify-center gap-1 sm:hidden">
           <span className="text-xs text-muted-foreground uppercase tracking-wide px-1">KO</span>
           <Button

--- a/src/index.css
+++ b/src/index.css
@@ -97,3 +97,97 @@
     margin: 0;
   }
 }
+
+@layer utilities {
+  @keyframes next-button-entrance {
+    0% {
+      opacity: 0;
+      transform: translateY(18px) scale(0.94);
+    }
+
+    60% {
+      opacity: 1;
+      transform: translateY(-4px) translateX(-4px) scale(1.02);
+    }
+
+    82% {
+      opacity: 1;
+      transform: translateY(0) translateX(5px) scale(1);
+    }
+
+    100% {
+      opacity: 1;
+      transform: translateY(0) translateX(0) scale(1);
+    }
+  }
+
+  .animate-next-button-entrance {
+    animation: next-button-entrance 700ms cubic-bezier(0.22, 1, 0.36, 1) 120ms both;
+    will-change: transform, opacity;
+  }
+
+  @keyframes hourglass-hover-nudge {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    35% {
+      transform: rotate(16deg);
+    }
+
+    65% {
+      transform: rotate(-10deg);
+    }
+
+    100% {
+      transform: rotate(0deg);
+    }
+  }
+
+  .hourglass-hover-nudge {
+    transform-origin: center;
+  }
+
+  @keyframes active-player-card-bounce {
+    0% {
+      transform: translateY(0) scale(1);
+    }
+
+    32% {
+      transform: translateY(-8px) scale(1.015);
+    }
+
+    58% {
+      transform: translateY(2px) scale(0.995);
+    }
+
+    100% {
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .animate-active-player-card-bounce {
+    animation: active-player-card-bounce 360ms cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: transform;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .group:hover .hourglass-hover-nudge {
+      animation: hourglass-hover-nudge 360ms cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-next-button-entrance {
+      animation: none;
+    }
+
+    .group:hover .hourglass-hover-nudge {
+      animation: none;
+    }
+
+    .animate-active-player-card-bounce {
+      animation: none;
+    }
+  }
+}

--- a/src/lib/__tests__/liveGame.test.ts
+++ b/src/lib/__tests__/liveGame.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import { buildLiveGameSession, changeCommanderDamage, changePlayerCounter } from "@/lib/liveGame"
+import type { LiveGameSetup, Player } from "@/types"
+
+function makePlayer(id: string, seatPosition: Player["seatPosition"]): Player {
+	return {
+		id,
+		isMe: id === "p1",
+		commanderName: `Commander ${id}`,
+		seatPosition,
+		fastMana: { hasFastMana: false, cards: [] },
+	}
+}
+
+function makeSetup(): LiveGameSetup {
+	return {
+		startingPlayerId: "p1",
+		players: [
+			makePlayer("p1", 1),
+			makePlayer("p2", 2),
+			makePlayer("p3", 3),
+			makePlayer("p4", 4),
+		],
+	}
+}
+
+function getPlayerLife(session: ReturnType<typeof buildLiveGameSession>, playerId: string) {
+	const player = session.players.find((candidate) => candidate.id === playerId)
+	expect(player).toBeDefined()
+	return player!
+}
+
+describe("liveGame lethal condition updates", () => {
+	it("eliminates and revives a player based on life total", () => {
+		const session = buildLiveGameSession(makeSetup(), 1)
+
+		const knockedOut = changePlayerCounter(session, "p2", "life", -40, 2)
+		expect(getPlayerLife(knockedOut, "p2").lifeTotal).toBe(0)
+		expect(getPlayerLife(knockedOut, "p2").isEliminated).toBe(true)
+
+		const revived = changePlayerCounter(knockedOut, "p2", "life", 1, 3)
+		expect(getPlayerLife(revived, "p2").lifeTotal).toBe(1)
+		expect(getPlayerLife(revived, "p2").isEliminated).toBe(false)
+		expect(getPlayerLife(revived, "p2").eliminatedAtTurn).toBeUndefined()
+	})
+
+	it("eliminates and revives a player based on poison counters", () => {
+		const session = buildLiveGameSession(makeSetup(), 1)
+
+		const knockedOut = changePlayerCounter(session, "p2", "poison", 10, 2)
+		expect(getPlayerLife(knockedOut, "p2").poisonCounters).toBe(10)
+		expect(getPlayerLife(knockedOut, "p2").isEliminated).toBe(true)
+
+		const revived = changePlayerCounter(knockedOut, "p2", "poison", -1, 3)
+		expect(getPlayerLife(revived, "p2").poisonCounters).toBe(9)
+		expect(getPlayerLife(revived, "p2").isEliminated).toBe(false)
+	})
+
+	it("eliminates and revives a player when commander damage crosses 21", () => {
+		const session = buildLiveGameSession(makeSetup(), 1)
+
+		const knockedOut = changeCommanderDamage(session, "p2", "p1", 21, 2)
+		expect(getPlayerLife(knockedOut, "p2").commanderDamageTakenByPlayerId).toEqual({ p1: 21 })
+		expect(getPlayerLife(knockedOut, "p2").lifeTotal).toBe(19)
+		expect(getPlayerLife(knockedOut, "p2").isEliminated).toBe(true)
+
+		const revived = changeCommanderDamage(knockedOut, "p2", "p1", -1, 3)
+		expect(getPlayerLife(revived, "p2").commanderDamageTakenByPlayerId).toEqual({ p1: 20 })
+		expect(getPlayerLife(revived, "p2").lifeTotal).toBe(20)
+		expect(getPlayerLife(revived, "p2").isEliminated).toBe(false)
+		expect(getPlayerLife(revived, "p2").eliminatedAtTurn).toBeUndefined()
+	})
+
+	it("does not revive a player if another lethal condition still applies", () => {
+		const session = buildLiveGameSession(makeSetup(), 1)
+
+		const withPoison = changePlayerCounter(session, "p2", "poison", 10, 2)
+		const withPoisonAndCommander = changeCommanderDamage(withPoison, "p2", "p1", 21, 3)
+		expect(getPlayerLife(withPoisonAndCommander, "p2").isEliminated).toBe(true)
+
+		const stillOut = changeCommanderDamage(withPoisonAndCommander, "p2", "p1", -1, 4)
+		expect(getPlayerLife(stillOut, "p2").commanderDamageTakenByPlayerId).toEqual({ p1: 20 })
+		expect(getPlayerLife(stillOut, "p2").poisonCounters).toBe(10)
+		expect(getPlayerLife(stillOut, "p2").isEliminated).toBe(true)
+	})
+	})

--- a/src/lib/liveGame.ts
+++ b/src/lib/liveGame.ts
@@ -1,0 +1,369 @@
+import type { Game, LiveGameActionType, LiveGameSession, LiveGameSetup, LiveGameSummary, LiveGameTrackedPlayer, Player } from "@/types"
+
+function generateId() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+function getNowIso(now = Date.now()) {
+  return new Date(now).toISOString()
+}
+
+function orderPlayersFromStartingSeat<T extends { id: string; seatPosition: number }>(players: T[], startingPlayerId: string): T[] {
+  const seatOrdered = [...players].sort((a, b) => a.seatPosition - b.seatPosition)
+  const startIndex = seatOrdered.findIndex((player) => player.id === startingPlayerId)
+
+  if (startIndex === -1) {
+    return seatOrdered
+  }
+
+  return [...seatOrdered.slice(startIndex), ...seatOrdered.slice(0, startIndex)]
+}
+
+function flushActivePlayerTime(session: LiveGameSession, now = Date.now()): LiveGameSession {
+  const elapsed = Math.max(0, now - new Date(session.activePlayerStartedAt).getTime())
+  if (elapsed === 0) return session
+
+  return {
+    ...session,
+    players: session.players.map((player) =>
+      player.id === session.activePlayerId
+        ? { ...player, elapsedMs: player.elapsedMs + elapsed }
+        : player
+    ),
+    activePlayerStartedAt: getNowIso(now),
+    updatedAt: getNowIso(now),
+  }
+}
+
+function getOrderedPlayers(session: LiveGameSession): LiveGameTrackedPlayer[] {
+  return orderPlayersFromStartingSeat(session.players, session.startingPlayerId)
+}
+
+function findNextActivePlayerId(session: LiveGameSession): string {
+  const orderedPlayers = getOrderedPlayers(session)
+  const alivePlayers = orderedPlayers.filter((player) => !player.isEliminated)
+  if (alivePlayers.length === 0) {
+    return session.activePlayerId
+  }
+
+  const currentIndex = alivePlayers.findIndex((player) => player.id === session.activePlayerId)
+  if (currentIndex === -1) {
+    return alivePlayers[0].id
+  }
+
+  return alivePlayers[(currentIndex + 1) % alivePlayers.length].id
+}
+
+function shouldAutoEliminate(player: LiveGameTrackedPlayer): boolean {
+  if (player.lifeTotal <= 0) return true
+  if (player.poisonCounters >= 10) return true
+  return Object.values(player.commanderDamageTakenByPlayerId).some((damage) => damage >= 21)
+}
+
+function applyAutoElimination(player: LiveGameTrackedPlayer, turnNumber: number): LiveGameTrackedPlayer {
+  if (!shouldAutoEliminate(player)) return player
+  if (player.isEliminated) return player
+  return { ...player, isEliminated: true, eliminatedAtTurn: turnNumber }
+}
+
+function shouldAutoRevive(player: LiveGameTrackedPlayer): boolean {
+  if (!player.isEliminated) return false
+  return !shouldAutoEliminate(player)
+}
+
+function applyAutoRevive(player: LiveGameTrackedPlayer): LiveGameTrackedPlayer {
+  if (!shouldAutoRevive(player)) return player
+  return { ...player, isEliminated: false, eliminatedAtTurn: undefined }
+}
+
+function applyAutoStatusUpdate(player: LiveGameTrackedPlayer, turnNumber: number): LiveGameTrackedPlayer {
+  if (player.isEliminated) return applyAutoRevive(player)
+  return applyAutoElimination(player, turnNumber)
+}
+
+export function buildLiveGameSession(setup: LiveGameSetup, now = Date.now()): LiveGameSession {
+  const orderedPlayers = orderPlayersFromStartingSeat(setup.players, setup.startingPlayerId)
+  const trackedPlayers: LiveGameTrackedPlayer[] = orderedPlayers.map((player) => ({
+    ...player,
+    lifeTotal: 40,
+    poisonCounters: 0,
+    commanderDamageTakenByPlayerId: {},
+    elapsedMs: 0,
+    isEliminated: false,
+  }))
+
+  const timestamp = getNowIso(now)
+
+  return {
+    id: generateId(),
+    stage: "tracking",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    startedAt: timestamp,
+    activePlayerStartedAt: timestamp,
+    turnNumber: 1,
+    startingPlayerId: setup.startingPlayerId,
+    activePlayerId: setup.startingPlayerId,
+    players: trackedPlayers,
+    bracket: setup.bracket,
+    actions: [],
+  }
+}
+
+export function changePlayerCounter(
+  session: LiveGameSession,
+  targetPlayerId: string,
+  type: LiveGameActionType,
+  delta: number,
+  now = Date.now()
+): LiveGameSession {
+  const flushed = flushActivePlayerTime(session, now)
+  let activePlayerEliminatedByUpdate = false
+
+  const updatedPlayers = flushed.players.map((player) => {
+    if (player.id !== targetPlayerId) return player
+
+    const updated = type === "life"
+      ? { ...player, lifeTotal: player.lifeTotal + delta }
+      : { ...player, poisonCounters: Math.max(0, player.poisonCounters + delta) }
+
+    const withAutoElimination = applyAutoStatusUpdate(updated, flushed.turnNumber)
+    if (withAutoElimination.id === flushed.activePlayerId && withAutoElimination.isEliminated) {
+      activePlayerEliminatedByUpdate = true
+    }
+
+    return withAutoElimination
+  })
+
+  const withUpdatedPlayers: LiveGameSession = {
+    ...flushed,
+    players: updatedPlayers,
+  }
+
+  const nextActivePlayerId = activePlayerEliminatedByUpdate
+    ? findNextActivePlayerId(withUpdatedPlayers)
+    : flushed.activePlayerId
+
+  return {
+    ...withUpdatedPlayers,
+    activePlayerId: nextActivePlayerId,
+    activePlayerStartedAt: activePlayerEliminatedByUpdate ? getNowIso(now) : flushed.activePlayerStartedAt,
+    actions: [
+      ...flushed.actions,
+      {
+        id: generateId(),
+        type,
+        turnNumber: flushed.turnNumber,
+        actingPlayerId: flushed.activePlayerId,
+        targetPlayerId,
+        delta,
+        createdAt: getNowIso(now),
+      },
+    ],
+    updatedAt: getNowIso(now),
+  }
+}
+
+export function changeCommanderDamage(
+  session: LiveGameSession,
+  targetPlayerId: string,
+  sourcePlayerId: string,
+  delta: number,
+  now = Date.now()
+): LiveGameSession {
+  const flushed = flushActivePlayerTime(session, now)
+  let activePlayerEliminatedByUpdate = false
+
+  const updatedPlayers = flushed.players.map((player) => {
+    if (player.id !== targetPlayerId) return player
+
+    const current = player.commanderDamageTakenByPlayerId[sourcePlayerId] ?? 0
+    const nextValue = Math.max(0, current + delta)
+    const nextMap = { ...player.commanderDamageTakenByPlayerId }
+
+    if (nextValue === 0) {
+      delete nextMap[sourcePlayerId]
+    } else {
+      nextMap[sourcePlayerId] = nextValue
+    }
+
+    const updated = {
+      ...player,
+      commanderDamageTakenByPlayerId: nextMap,
+      lifeTotal: player.lifeTotal - delta,
+    }
+
+    const withAutoElimination = applyAutoStatusUpdate(updated, flushed.turnNumber)
+    if (withAutoElimination.id === flushed.activePlayerId && withAutoElimination.isEliminated) {
+      activePlayerEliminatedByUpdate = true
+    }
+
+    return withAutoElimination
+  })
+
+  const withUpdatedPlayers: LiveGameSession = {
+    ...flushed,
+    players: updatedPlayers,
+  }
+
+  const nextActivePlayerId = activePlayerEliminatedByUpdate
+    ? findNextActivePlayerId(withUpdatedPlayers)
+    : flushed.activePlayerId
+
+  return {
+    ...withUpdatedPlayers,
+    activePlayerId: nextActivePlayerId,
+    activePlayerStartedAt: activePlayerEliminatedByUpdate ? getNowIso(now) : flushed.activePlayerStartedAt,
+    actions: [
+      ...flushed.actions,
+      {
+        id: generateId(),
+        type: "commander-damage",
+        turnNumber: flushed.turnNumber,
+        actingPlayerId: flushed.activePlayerId,
+        targetPlayerId,
+        sourcePlayerId,
+        delta,
+        createdAt: getNowIso(now),
+      },
+    ],
+    updatedAt: getNowIso(now),
+  }
+}
+
+export function setPlayerEliminated(session: LiveGameSession, playerId: string, isEliminated: boolean, now = Date.now()): LiveGameSession {
+  const flushed = flushActivePlayerTime(session, now)
+  const updatedPlayers = flushed.players.map((player) => {
+    if (player.id !== playerId) return player
+    if (!isEliminated) {
+      return { ...player, isEliminated: false, eliminatedAtTurn: undefined }
+    }
+    return { ...player, isEliminated: true, eliminatedAtTurn: flushed.turnNumber }
+  })
+
+  let nextActivePlayerId = flushed.activePlayerId
+  if (playerId === flushed.activePlayerId && isEliminated) {
+    const withUpdatedPlayers = { ...flushed, players: updatedPlayers }
+    nextActivePlayerId = findNextActivePlayerId(withUpdatedPlayers)
+  }
+
+  return {
+    ...flushed,
+    players: updatedPlayers,
+    activePlayerId: nextActivePlayerId,
+    activePlayerStartedAt: getNowIso(now),
+    updatedAt: getNowIso(now),
+  }
+}
+
+export function advanceLiveGameTurn(session: LiveGameSession, now = Date.now()): LiveGameSession {
+  const flushed = flushActivePlayerTime(session, now)
+  const orderedPlayers = getOrderedPlayers(flushed).filter((player) => !player.isEliminated)
+  if (orderedPlayers.length === 0) return flushed
+
+  const currentIndex = orderedPlayers.findIndex((player) => player.id === flushed.activePlayerId)
+  const nextPlayer = orderedPlayers[(currentIndex + 1 + orderedPlayers.length) % orderedPlayers.length]
+  const wrappedToStart = nextPlayer.id === flushed.startingPlayerId && nextPlayer.id !== flushed.activePlayerId
+
+  return {
+    ...flushed,
+    activePlayerId: nextPlayer.id,
+    activePlayerStartedAt: getNowIso(now),
+    turnNumber: wrappedToStart ? flushed.turnNumber + 1 : flushed.turnNumber,
+    updatedAt: getNowIso(now),
+  }
+}
+
+export function prepareLiveGameForFinalize(session: LiveGameSession, now = Date.now()): LiveGameSession {
+  return {
+    ...flushActivePlayerTime(session, now),
+    stage: "finalize",
+    winTurn: session.winTurn ?? session.turnNumber,
+    updatedAt: getNowIso(now),
+  }
+}
+
+export function updateLiveGameFinalization(
+  session: LiveGameSession,
+  patch: Pick<LiveGameSession, "winnerId" | "winTurn" | "winConditions" | "keyWinconCards" | "notes">,
+  now = Date.now()
+): LiveGameSession {
+  return {
+    ...session,
+    ...patch,
+    updatedAt: getNowIso(now),
+  }
+}
+
+export function buildGameFromLiveSession(session: LiveGameSession, now = Date.now()): Game {
+  const endedAt = getNowIso(now)
+  const finalized = flushActivePlayerTime(session, now)
+  const winnerId = finalized.winnerId ?? finalized.players[0]?.id ?? ""
+  const winTurn = finalized.winTurn ?? finalized.turnNumber
+
+  const players: Player[] = finalized.players.map((player) => ({
+    id: player.id,
+    isMe: player.isMe,
+    commanderName: player.commanderName,
+    commanderImageUri: player.commanderImageUri,
+    commanderColorIdentity: player.commanderColorIdentity,
+    commanderManaCost: player.commanderManaCost,
+    commanderTypeLine: player.commanderTypeLine,
+    partnerName: player.partnerName,
+    partnerImageUri: player.partnerImageUri,
+    partnerManaCost: player.partnerManaCost,
+    partnerTypeLine: player.partnerTypeLine,
+    knockoutTurn: player.id === winnerId ? undefined : player.eliminatedAtTurn ?? winTurn,
+    seatPosition: player.seatPosition,
+    displayName: player.displayName,
+    fastMana: player.fastMana,
+    commanderDamageTakenByPlayerId: player.commanderDamageTakenByPlayerId,
+  }))
+
+  const playerNames = players.every((player) => player.displayName?.trim())
+    ? Object.fromEntries(players.map((player) => [player.id, player.displayName!.trim()]))
+    : undefined
+
+  const summary: LiveGameSummary = {
+    startedAt: finalized.startedAt,
+    endedAt,
+    durationMs: Math.max(0, new Date(endedAt).getTime() - new Date(finalized.startedAt).getTime()),
+    startingPlayerId: finalized.startingPlayerId,
+    playerElapsedMs: Object.fromEntries(finalized.players.map((player) => [player.id, player.elapsedMs])),
+    finalLifeTotals: Object.fromEntries(finalized.players.map((player) => [player.id, player.lifeTotal])),
+    finalPoisonCounters: Object.fromEntries(finalized.players.map((player) => [player.id, player.poisonCounters])),
+    finalCommanderDamageTakenByPlayerId: Object.fromEntries(
+      finalized.players.map((player) => [player.id, player.commanderDamageTakenByPlayerId])
+    ),
+    actions: finalized.actions,
+  }
+
+  return {
+    id: generateId(),
+    playedAt: endedAt,
+    players,
+    winnerId,
+    winTurn,
+    notes: finalized.notes?.trim() || undefined,
+    winConditions: finalized.winConditions?.length ? finalized.winConditions : undefined,
+    keyWinconCards: finalized.keyWinconCards?.length ? finalized.keyWinconCards : undefined,
+    bracket: finalized.bracket,
+    playerNames,
+    startedAt: finalized.startedAt,
+    endedAt,
+    durationMs: summary.durationMs,
+    startingPlayerId: finalized.startingPlayerId,
+    liveSummary: summary,
+  }
+}
+
+export function getLiveGamePlayerElapsedMs(session: LiveGameSession, playerId: string, now = Date.now()): number {
+  const player = session.players.find((entry) => entry.id === playerId)
+  if (!player) return 0
+  if (session.activePlayerId !== playerId) return player.elapsedMs
+  return player.elapsedMs + Math.max(0, now - new Date(session.activePlayerStartedAt).getTime())
+}
+
+export function getLiveGameDurationMs(session: LiveGameSession, now = Date.now()): number {
+  return Math.max(0, now - new Date(session.startedAt).getTime())
+}

--- a/src/lib/liveGameStorage.ts
+++ b/src/lib/liveGameStorage.ts
@@ -1,0 +1,22 @@
+import type { LiveGameSession } from "@/types"
+
+function getStorageKey(userId: string) {
+  return `commando_live_game:${userId}`
+}
+
+export function loadLiveGameSession(userId: string): LiveGameSession | null {
+  try {
+    const raw = localStorage.getItem(getStorageKey(userId))
+    return raw ? (JSON.parse(raw) as LiveGameSession) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveLiveGameSession(userId: string, session: LiveGameSession): void {
+  localStorage.setItem(getStorageKey(userId), JSON.stringify(session))
+}
+
+export function clearLiveGameSession(userId: string): void {
+  localStorage.removeItem(getStorageKey(userId))
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -41,6 +41,10 @@ interface ExportPlayer {
 
 interface ExportGame {
   playedAt: string        // YYYY-MM-DD
+  startedAt?: string
+  endedAt?: string
+  durationMs?: number
+  startingPlayerIndex?: number
   winTurn: number
   winnerIndex: number     // index into players array (0 = you)
   notes?: string
@@ -49,6 +53,7 @@ interface ExportGame {
   bracket?: number        // 1-5, optional power level bracket
   podId?: string
   playerNames?: Record<string, string>
+  liveSummary?: Game["liveSummary"]
   players: ExportPlayer[]
 }
 
@@ -63,8 +68,15 @@ export function exportData(): string {
 
   const exportGames: ExportGame[] = games.map((g) => {
     const winnerIndex = g.players.findIndex((p) => p.id === g.winnerId)
+    const startingPlayerIndex = g.startingPlayerId
+      ? g.players.findIndex((p) => p.id === g.startingPlayerId)
+      : undefined
     return {
       playedAt: g.playedAt.slice(0, 10),
+      startedAt: g.startedAt,
+      endedAt: g.endedAt,
+      durationMs: g.durationMs,
+      startingPlayerIndex: startingPlayerIndex !== undefined && startingPlayerIndex >= 0 ? startingPlayerIndex : undefined,
       winTurn: g.winTurn,
       winnerIndex: winnerIndex >= 0 ? winnerIndex : 0,
       notes: g.notes,
@@ -73,6 +85,7 @@ export function exportData(): string {
       bracket: g.bracket,
       podId: g.podId,
       playerNames: g.playerNames,
+      liveSummary: g.liveSummary,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       players: g.players.map(({ id: _id, isMe: _isMe, ...rest }) => rest as ExportPlayer),
     }
@@ -303,6 +316,10 @@ export function parseImportJson(json: string): { success: boolean; games: Game[]
         return {
           id: generateId(),
           playedAt: typeof g.playedAt === "string" ? new Date(g.playedAt).toISOString() : new Date().toISOString(),
+          startedAt: typeof g.startedAt === "string" ? g.startedAt : undefined,
+          endedAt: typeof g.endedAt === "string" ? g.endedAt : undefined,
+          durationMs: typeof g.durationMs === "number" ? g.durationMs : undefined,
+          startingPlayerId: typeof g.startingPlayerIndex === "number" ? players[g.startingPlayerIndex]?.id : undefined,
           winTurn: typeof g.winTurn === "number" ? g.winTurn : 0,
           winnerId: players[g.winnerIndex]?.id ?? players[0].id,
           podId: typeof g.podId === "string" ? g.podId : undefined,
@@ -310,6 +327,7 @@ export function parseImportJson(json: string): { success: boolean; games: Game[]
           winConditions: Array.isArray(g.winConditions) ? g.winConditions as string[] : undefined,
           keyWinconCards: Array.isArray(g.keyWinconCards) ? g.keyWinconCards as string[] : undefined,
           bracket: typeof g.bracket === "number" ? g.bracket : undefined,
+          liveSummary: g.liveSummary as Game["liveSummary"],
           playerNames,
           players,
         } as Game

--- a/src/lib/supabaseStorage.ts
+++ b/src/lib/supabaseStorage.ts
@@ -9,6 +9,13 @@ import { supabase } from "@/lib/supabase"
 import type { Game, Player } from "@/types"
 import type { GameRow, DbPlayer } from "@/types/database"
 
+function isMissingColumnError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const maybe = error as { message?: string; details?: string; hint?: string }
+  const text = `${maybe.message ?? ""} ${maybe.details ?? ""} ${maybe.hint ?? ""}`.toLowerCase()
+  return text.includes("column") && text.includes("does not exist")
+}
+
 async function getCurrentUserId(): Promise<string> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sessionResp = await (supabase as any).auth.getSession()
@@ -74,6 +81,10 @@ function rowToGame(row: GameRow): Game {
   return {
     id: row.id,
     playedAt: row.played_at,
+    startedAt: row.started_at ?? undefined,
+    endedAt: row.ended_at ?? undefined,
+    durationMs: row.duration_ms ?? undefined,
+    startingPlayerId: row.starting_player_id ?? undefined,
     players,
     winnerId: row.winner_player_id,
     winTurn: row.win_turn,
@@ -81,6 +92,7 @@ function rowToGame(row: GameRow): Game {
     winConditions: row.win_conditions ?? undefined,
     keyWinconCards: row.key_wincon_cards ?? undefined,
     bracket: row.bracket ?? undefined,
+    liveSummary: row.live_summary ?? undefined,
     playerNames,
   }
 }
@@ -105,50 +117,107 @@ export async function insertGame(game: Game): Promise<Game> {
     insert: (values: unknown) => { select: () => { single: () => Promise<{ data: unknown; error: unknown }> } }
   }
 
-  const { data, error } = await gamesTable
-    .insert({
-      user_id: userId,
-      played_at: game.playedAt,
-      win_turn: game.winTurn,
-      winner_player_id: game.winnerId,
-      notes: game.notes ?? null,
-      win_conditions: game.winConditions ?? null,
-      key_wincon_cards: game.keyWinconCards ?? null,
-      bracket: game.bracket ?? null,
-      players: game.players.map(playerToDb) as unknown as GameRow["players"],
-    })
-    .select()
-    .single()
+  const payloadWithLive = {
+    user_id: userId,
+    played_at: game.playedAt,
+    started_at: game.startedAt ?? null,
+    ended_at: game.endedAt ?? null,
+    duration_ms: game.durationMs ?? null,
+    starting_player_id: game.startingPlayerId ?? null,
+    win_turn: game.winTurn,
+    winner_player_id: game.winnerId,
+    notes: game.notes ?? null,
+    win_conditions: game.winConditions ?? null,
+    key_wincon_cards: game.keyWinconCards ?? null,
+    bracket: game.bracket ?? null,
+    live_summary: game.liveSummary ?? null,
+    players: game.players.map(playerToDb) as unknown as GameRow["players"],
+  }
 
-  if (error) throw error
-  return rowToGame(data as GameRow)
+  const payloadLegacy = {
+    user_id: userId,
+    played_at: game.playedAt,
+    win_turn: game.winTurn,
+    winner_player_id: game.winnerId,
+    notes: game.notes ?? null,
+    win_conditions: game.winConditions ?? null,
+    key_wincon_cards: game.keyWinconCards ?? null,
+    bracket: game.bracket ?? null,
+    players: game.players.map(playerToDb) as unknown as GameRow["players"],
+  }
+
+  let result = await gamesTable.insert(payloadWithLive).select().single()
+  if (result.error && isMissingColumnError(result.error)) {
+    result = await gamesTable.insert(payloadLegacy).select().single()
+  }
+
+  if (result.error) throw result.error
+  return rowToGame(result.data as GameRow)
 }
 
 export async function patchGame(id: string, patch: Partial<Game>): Promise<Game> {
   // Build the update object, only including fields that are present in the patch
   const update: Record<string, unknown> = {}
+  const legacyUpdate: Record<string, unknown> = {}
 
-  if (patch.playedAt !== undefined) update.played_at = patch.playedAt
-  if (patch.winTurn !== undefined) update.win_turn = patch.winTurn
-  if (patch.winnerId !== undefined) update.winner_player_id = patch.winnerId
-  if (patch.notes !== undefined) update.notes = patch.notes ?? null
-  if (patch.winConditions !== undefined) update.win_conditions = patch.winConditions ?? null
-  if (patch.keyWinconCards !== undefined) update.key_wincon_cards = patch.keyWinconCards ?? null
-  if (patch.bracket !== undefined) update.bracket = patch.bracket ?? null
-  if (patch.players !== undefined) update.players = patch.players.map(playerToDb)
+  if (patch.playedAt !== undefined) {
+    update.played_at = patch.playedAt
+    legacyUpdate.played_at = patch.playedAt
+  }
+  if (patch.startedAt !== undefined) update.started_at = patch.startedAt ?? null
+  if (patch.endedAt !== undefined) update.ended_at = patch.endedAt ?? null
+  if (patch.durationMs !== undefined) update.duration_ms = patch.durationMs ?? null
+  if (patch.startingPlayerId !== undefined) update.starting_player_id = patch.startingPlayerId ?? null
+  if (patch.winTurn !== undefined) {
+    update.win_turn = patch.winTurn
+    legacyUpdate.win_turn = patch.winTurn
+  }
+  if (patch.winnerId !== undefined) {
+    update.winner_player_id = patch.winnerId
+    legacyUpdate.winner_player_id = patch.winnerId
+  }
+  if (patch.notes !== undefined) {
+    update.notes = patch.notes ?? null
+    legacyUpdate.notes = patch.notes ?? null
+  }
+  if (patch.winConditions !== undefined) {
+    update.win_conditions = patch.winConditions ?? null
+    legacyUpdate.win_conditions = patch.winConditions ?? null
+  }
+  if (patch.keyWinconCards !== undefined) {
+    update.key_wincon_cards = patch.keyWinconCards ?? null
+    legacyUpdate.key_wincon_cards = patch.keyWinconCards ?? null
+  }
+  if (patch.bracket !== undefined) {
+    update.bracket = patch.bracket ?? null
+    legacyUpdate.bracket = patch.bracket ?? null
+  }
+  if (patch.liveSummary !== undefined) update.live_summary = patch.liveSummary ?? null
+  if (patch.players !== undefined) {
+    update.players = patch.players.map(playerToDb)
+    legacyUpdate.players = patch.players.map(playerToDb)
+  }
 
   const gamesTable = supabase.from("games") as unknown as {
     update: (values: unknown) => { eq: (column: string, value: string) => { select: () => { single: () => Promise<{ data: unknown; error: unknown }> } } }
   }
 
-  const { data, error } = await gamesTable
+  let result = await gamesTable
     .update(update)
     .eq("id", id)
     .select()
     .single()
 
-  if (error) throw error
-  return rowToGame(data as GameRow)
+  if (result.error && isMissingColumnError(result.error)) {
+    result = await gamesTable
+      .update(legacyUpdate)
+      .eq("id", id)
+      .select()
+      .single()
+  }
+
+  if (result.error) throw result.error
+  return rowToGame(result.data as GameRow)
 }
 
 export async function removeGame(id: string): Promise<void> {
@@ -199,7 +268,24 @@ export async function replaceAllGames(games: Game[]): Promise<Game[]> {
     })
   }
 
-  const rows = games.map((game, idx) => ({
+  const rowsWithLive = games.map((game, idx) => ({
+    user_id: userId,
+    played_at: adjustedPlayedAts[idx] ?? game.playedAt,
+    started_at: game.startedAt ?? null,
+    ended_at: game.endedAt ?? null,
+    duration_ms: game.durationMs ?? null,
+    starting_player_id: game.startingPlayerId ?? null,
+    win_turn: game.winTurn,
+    winner_player_id: game.winnerId,
+    notes: game.notes ?? null,
+    win_conditions: game.winConditions ?? null,
+    key_wincon_cards: game.keyWinconCards ?? null,
+    bracket: game.bracket ?? null,
+    live_summary: game.liveSummary ?? null,
+    players: game.players.map(playerToDb) as unknown as GameRow["players"],
+  }))
+
+  const rowsLegacy = games.map((game, idx) => ({
     user_id: userId,
     played_at: adjustedPlayedAts[idx] ?? game.playedAt,
     win_turn: game.winTurn,
@@ -216,7 +302,10 @@ export async function replaceAllGames(games: Game[]): Promise<Game[]> {
     insert: (values: unknown) => { select: () => Promise<{ data: unknown; error: unknown }> }
   }
 
-  const { data, error } = await gamesTable.insert(rows).select()
-  if (error) throw error
-  return (data as GameRow[]).map(rowToGame)
+  let result = await gamesTable.insert(rowsWithLive).select()
+  if (result.error && isMissingColumnError(result.error)) {
+    result = await gamesTable.insert(rowsLegacy).select()
+  }
+  if (result.error) throw result.error
+  return (result.data as GameRow[]).map(rowToGame)
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useEffect, useRef, useCallback } from "react"
 import { Plus, ArrowRight, Pencil, ChevronLeft, ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
+import { NewGameMenu } from "@/components/NewGameMenu"
 import { GameHistoryRow } from "@/components/GameHistoryRow"
 import { useStats } from "@/hooks/useStats"
 import { fetchCardByName, resolveArtCrop } from "@/lib/scryfall"
@@ -12,10 +12,13 @@ interface DashboardPageProps {
   games: Game[]
   onNavigate: (path: string) => void
   onOpenLogGame: (commanderName?: string) => void
+  onOpenLiveGame: (commanderName?: string) => void
+  onResumeLiveGame: () => void
+  hasLiveGame?: boolean
   onEditGame: (id: string) => void
 }
 
-export function DashboardPage({ games, onNavigate, onOpenLogGame, onEditGame }: DashboardPageProps) {
+export function DashboardPage({ games, onNavigate, onOpenLogGame, onOpenLiveGame, onResumeLiveGame, hasLiveGame = false, onEditGame }: DashboardPageProps) {
   const stats = useStats(games)
 
   const recentGames = useMemo(() => {
@@ -58,20 +61,32 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame, onEditGame }: 
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="rounded-lg border bg-card p-3 flex flex-col items-center">
-              <img
-                src={artUri ?? ""}
-                alt={name}
-                className="w-full h-32 rounded object-cover bg-muted"
+              {artUri ? (
+                <img
+                  src={artUri}
+                  alt={name}
+                  className="w-full h-32 rounded object-cover bg-muted"
+                />
+              ) : (
+                <div className="w-full h-32 rounded bg-muted" aria-hidden="true" />
+              )}
+              <NewGameMenu
+                hasLiveGame={hasLiveGame}
+                prefillCommander={name}
+                onQuickLog={onOpenLogGame}
+                onStartLiveGame={onOpenLiveGame}
+                onResumeLiveGame={onResumeLiveGame}
+                trigger={
+                  <Button
+                    size="sm"
+                    className="mt-2 w-full gap-1.5"
+                    variant="outline"
+                  >
+                    <Plus className="h-4 w-4" />
+                    Track game
+                  </Button>
+                }
               />
-              <Button
-                size="sm"
-                className="mt-2 w-full gap-1.5"
-                variant="outline"
-                onClick={() => onOpenLogGame(name)}
-              >
-                <Plus className="h-4 w-4" />
-                Track game
-              </Button>
             </div>
           </TooltipTrigger>
           <TooltipContent>
@@ -122,8 +137,12 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame, onEditGame }: 
               Log a game to see your stats here.
             </p>
           </div>
-          <Popover>
-            <PopoverTrigger asChild>
+          <NewGameMenu
+            hasLiveGame={hasLiveGame}
+            onQuickLog={onOpenLogGame}
+            onStartLiveGame={onOpenLiveGame}
+            onResumeLiveGame={onResumeLiveGame}
+            trigger={
               <Button className="gap-1.5">
                 <Plus className="h-4 w-4" />
                 Track a game
@@ -131,13 +150,8 @@ export function DashboardPage({ games, onNavigate, onOpenLogGame, onEditGame }: 
                   N
                 </kbd>
               </Button>
-            </PopoverTrigger>
-            <PopoverContent>
-              <div className="flex flex-col gap-2">
-                <Button variant="ghost" onClick={() => onOpenLogGame?.()}>Log a game</Button>
-              </div>
-            </PopoverContent>
-          </Popover>
+            }
+          />
         </div>
       </div>
     )

--- a/src/pages/LiveGamePage.tsx
+++ b/src/pages/LiveGamePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import { AlertCircle, Clock3, Play, Skull } from "lucide-react"
+import { AlertCircle, Clock3, Hourglass, Play, Skull } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -189,12 +189,62 @@ export function LiveGamePage({
 
   // Draggable Next button
   const [nextBtnPos, setNextBtnPos] = useState<{ x: number; y: number } | null>(null)
+  const [nextBtnMenuOpen, setNextBtnMenuOpen] = useState(false)
+  const [nextBtnFlipped, setNextBtnFlipped] = useState(false)
+  const [activePlayerBounceId, setActivePlayerBounceId] = useState<string | null>(null)
   const dragState = useRef<{ startX: number; startY: number; originX: number; originY: number; moved: boolean } | null>(null)
+  const nextBtnLongPressTimeoutRef = useRef<number | null>(null)
+  const nextBtnLongPressTriggeredRef = useRef(false)
+  const pendingActivePlayerBounceRef = useRef(false)
+  const activePlayerBounceTimeoutRef = useRef<number | null>(null)
+
+  function clearNextBtnLongPressTimeout() {
+    if (nextBtnLongPressTimeoutRef.current !== null) {
+      window.clearTimeout(nextBtnLongPressTimeoutRef.current)
+      nextBtnLongPressTimeoutRef.current = null
+    }
+  }
+
+  function clearActivePlayerBounceTimeout() {
+    if (activePlayerBounceTimeoutRef.current !== null) {
+      window.clearTimeout(activePlayerBounceTimeoutRef.current)
+      activePlayerBounceTimeoutRef.current = null
+    }
+  }
+
+  function getNextBtnMenuPos() {
+    const origin = nextBtnPos ?? getDefaultNextBtnPos()
+    return {
+      left: Math.min(origin.x + 76, window.innerWidth - 176),
+      top: Math.max(16, Math.min(origin.y + 8, window.innerHeight - 72)),
+    }
+  }
+
+  function openNextBtnMenu() {
+    clearNextBtnLongPressTimeout()
+    nextBtnLongPressTriggeredRef.current = true
+    setNextBtnMenuOpen(true)
+  }
+
+  function closeNextBtnMenu() {
+    clearNextBtnLongPressTimeout()
+    setNextBtnMenuOpen(false)
+  }
 
   function handleNextBtnPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
     e.currentTarget.setPointerCapture(e.pointerId)
     const origin = nextBtnPos ?? getDefaultNextBtnPos()
     dragState.current = { startX: e.clientX, startY: e.clientY, originX: origin.x, originY: origin.y, moved: false }
+    nextBtnLongPressTriggeredRef.current = false
+
+    if (e.pointerType !== "mouse") {
+      clearNextBtnLongPressTimeout()
+      nextBtnLongPressTimeoutRef.current = window.setTimeout(() => {
+        if (!dragState.current?.moved) {
+          openNextBtnMenu()
+        }
+      }, 500)
+    }
   }
 
   function handleNextBtnPointerMove(e: React.PointerEvent<HTMLButtonElement>) {
@@ -202,13 +252,34 @@ export function LiveGamePage({
     const dx = e.clientX - dragState.current.startX
     const dy = e.clientY - dragState.current.startY
     if (Math.abs(dx) > 3 || Math.abs(dy) > 3) dragState.current.moved = true
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
+      clearNextBtnLongPressTimeout()
+      closeNextBtnMenu()
+    }
     setNextBtnPos({ x: dragState.current.originX + dx, y: dragState.current.originY + dy })
   }
 
   function handleNextBtnPointerUp(_e: React.PointerEvent<HTMLButtonElement>) {
     const wasMoved = dragState.current?.moved ?? false
+    const wasLongPress = nextBtnLongPressTriggeredRef.current
     dragState.current = null
-    if (!wasMoved) handleAdvanceTurn()
+    clearNextBtnLongPressTimeout()
+    if (!wasMoved && !wasLongPress) {
+      closeNextBtnMenu()
+      handleAdvanceTurn()
+    }
+    nextBtnLongPressTriggeredRef.current = false
+  }
+
+  function handleNextBtnContextMenu(e: React.MouseEvent<HTMLButtonElement>) {
+    e.preventDefault()
+    openNextBtnMenu()
+  }
+
+  function handleNextBtnPointerCancel() {
+    dragState.current = null
+    clearNextBtnLongPressTimeout()
+    nextBtnLongPressTriggeredRef.current = false
   }
 
   function getDefaultNextBtnPos() {
@@ -243,6 +314,44 @@ export function LiveGamePage({
     setKeyWinconCards(session.keyWinconCards ?? [])
     setBracket(session.bracket ?? null)
   }, [session])
+
+  useEffect(() => {
+    if (!session?.activePlayerId || !pendingActivePlayerBounceRef.current) return
+
+    pendingActivePlayerBounceRef.current = false
+    setActivePlayerBounceId(session.activePlayerId)
+    clearActivePlayerBounceTimeout()
+    activePlayerBounceTimeoutRef.current = window.setTimeout(() => {
+      setActivePlayerBounceId((current) => (current === session.activePlayerId ? null : current))
+      activePlayerBounceTimeoutRef.current = null
+    }, 420)
+  }, [session?.activePlayerId])
+
+  useEffect(() => () => {
+    clearNextBtnLongPressTimeout()
+    clearActivePlayerBounceTimeout()
+  }, [])
+
+  useEffect(() => {
+    if (!nextBtnMenuOpen) return
+
+    function handleWindowPointerDown() {
+      closeNextBtnMenu()
+    }
+
+    function handleWindowKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        closeNextBtnMenu()
+      }
+    }
+
+    window.addEventListener("pointerdown", handleWindowPointerDown)
+    window.addEventListener("keydown", handleWindowKeyDown)
+    return () => {
+      window.removeEventListener("pointerdown", handleWindowPointerDown)
+      window.removeEventListener("keydown", handleWindowKeyDown)
+    }
+  }, [nextBtnMenuOpen])
 
   const recentMyCommanders = useMemo((): RecentCommander[] => {
     const seen = new Set<string>()
@@ -558,6 +667,8 @@ export function LiveGamePage({
   }
 
   function handleAdvanceTurn() {
+    setNextBtnFlipped((prev) => !prev)
+    pendingActivePlayerBounceRef.current = true
     setSession((prev) => {
       if (!prev) return prev
       return advanceLiveGameTurn(prev)
@@ -974,7 +1085,7 @@ export function LiveGamePage({
           const isWinnerSelected = session.winnerId === player.id
           const canReturnThisTurn = player.isEliminated && player.eliminatedAtTurn === session.turnNumber
           return (
-            <Card key={player.id} className={cn("relative overflow-hidden", isActive ? "border-primary shadow-md" : "border-border", player.isEliminated ? "opacity-75" : "") }>
+            <Card key={player.id} className={cn("relative overflow-hidden", isActive ? "border-primary shadow-md" : "border-border", activePlayerBounceId === player.id && "animate-active-player-card-bounce", player.isEliminated ? "opacity-75" : "") }>
               {player.commanderImageUri && (
                 <>
                   <img
@@ -1173,17 +1284,43 @@ export function LiveGamePage({
       {/* Draggable floating Next button */}
       {(() => {
         const pos = nextBtnPos ?? getDefaultNextBtnPos()
+        const menuPos = getNextBtnMenuPos()
         return (
-          <button
-            type="button"
-            style={{ position: "fixed", left: pos.x, top: pos.y, touchAction: "none", zIndex: 50 }}
-            onPointerDown={handleNextBtnPointerDown}
-            onPointerMove={handleNextBtnPointerMove}
-            onPointerUp={handleNextBtnPointerUp}
-            className="flex h-16 w-16 select-none items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground shadow-xl ring-2 ring-background active:scale-95"
-          >
-            Next
-          </button>
+          <>
+            {nextBtnMenuOpen && (
+              <div
+                style={{ position: "fixed", left: menuPos.left, top: menuPos.top, zIndex: 55 }}
+                className="min-w-36 rounded-xl border bg-background/95 p-1.5 shadow-xl backdrop-blur supports-[backdrop-filter]:bg-background/85"
+                onPointerDown={(event) => event.stopPropagation()}
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-start text-sm"
+                  onClick={() => {
+                    closeNextBtnMenu()
+                    handleEnterFinalize()
+                  }}
+                >
+                  End game
+                </Button>
+              </div>
+            )}
+            <button
+              type="button"
+              aria-label="Advance turn"
+              title="Advance turn"
+              style={{ position: "fixed", left: pos.x, top: pos.y, touchAction: "none", zIndex: 50 }}
+              onContextMenu={handleNextBtnContextMenu}
+              onPointerDown={handleNextBtnPointerDown}
+              onPointerMove={handleNextBtnPointerMove}
+              onPointerUp={handleNextBtnPointerUp}
+              onPointerCancel={handleNextBtnPointerCancel}
+              className="group animate-next-button-entrance flex h-16 w-16 select-none items-center justify-center rounded-full bg-primary text-primary-foreground shadow-xl ring-2 ring-background active:scale-95"
+            >
+              <Hourglass className={cn("hourglass-hover-nudge h-6 w-6 transition-transform duration-300 ease-out", nextBtnFlipped ? "rotate-180" : "rotate-0")} />
+            </button>
+          </>
         )
       })()}
     </div>

--- a/src/pages/LiveGamePage.tsx
+++ b/src/pages/LiveGamePage.tsx
@@ -1,0 +1,1191 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { AlertCircle, Clock3, Play, Skull } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Separator } from "@/components/ui/separator"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { PlayerRow } from "@/components/PlayerRow"
+import { CardSearch } from "@/components/CardSearch"
+import { fetchCardByName, resolveArtCrop } from "@/lib/scryfall"
+import { buildGameFromLiveSession, buildLiveGameSession, changeCommanderDamage, changePlayerCounter, getLiveGameDurationMs, getLiveGamePlayerElapsedMs, prepareLiveGameForFinalize, setPlayerEliminated, advanceLiveGameTurn, updateLiveGameFinalization } from "@/lib/liveGame"
+import { clearLiveGameSession, saveLiveGameSession } from "@/lib/liveGameStorage"
+import { loadProfile } from "@/lib/storage"
+import { cn } from "@/lib/utils"
+import type { Game, LiveGameSession, Player, RecentCommander, SeatPosition } from "@/types"
+
+function generateId() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+function makePlayer(isMe: boolean): Partial<Player> {
+  return {
+    id: generateId(),
+    isMe,
+    commanderName: "",
+    fastMana: { hasFastMana: false, cards: [] },
+  }
+}
+
+function formatDuration(ms: number) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  return [hours, minutes, seconds]
+    .map((value, index) => (index === 0 ? String(value) : String(value).padStart(2, "0")))
+    .join(":")
+}
+
+interface PlayerFieldErrors {
+  commanderName: boolean
+  seatPosition: boolean
+}
+
+interface SetupErrors {
+  playerCount: boolean
+  players: PlayerFieldErrors[]
+}
+
+function EditableNumber({ value, onCommit, className, disabled }: { value: number; onCommit: (v: number) => void; className?: string; disabled?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const isEditingRef = useRef(false)
+
+  useEffect(() => {
+    if (!isEditingRef.current && ref.current) {
+      ref.current.textContent = String(value)
+    }
+  }, [value])
+
+  return (
+    <div
+      ref={ref}
+      contentEditable={!disabled}
+      suppressContentEditableWarning
+      className={cn(
+        "outline-none [caret-color:currentColor]",
+        !disabled && "cursor-text",
+        disabled && "cursor-default",
+        className
+      )}
+      onFocus={(e) => {
+        isEditingRef.current = true
+        const range = document.createRange()
+        range.selectNodeContents(e.currentTarget)
+        const sel = window.getSelection()
+        sel?.removeAllRanges()
+        sel?.addRange(range)
+      }}
+      onBlur={(e) => {
+        isEditingRef.current = false
+        const parsed = parseInt(e.currentTarget.textContent ?? "", 10)
+        if (!isNaN(parsed)) {
+          onCommit(parsed)
+        } else if (ref.current) {
+          ref.current.textContent = String(value)
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault()
+          e.currentTarget.blur()
+        }
+        if (!/[\d\-]/.test(e.key) && !["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Tab", "Home", "End"].includes(e.key)) {
+          e.preventDefault()
+        }
+      }}
+    />
+  )
+}
+
+const EMPTY_SETUP_ERRORS: SetupErrors = {
+  playerCount: false,
+  players: [],
+}
+
+const WIN_CONDITION_CATEGORIES = [
+  "Commander Damage",
+  "Lethal Combat Damage",
+  "Combat Trick",
+  "Lethal Non-Combat Damage",
+  "Players Decked Out",
+  "Alternate Wincon",
+  "Infinite Loop",
+  "Infinite Life-Gain",
+  "Infinite Mana",
+  "Asymmetric Board Wipe",
+  "Poison or Infect",
+] as const
+
+function getMirroredSeatOrder(totalPlayers: number): number[] {
+  if (totalPlayers < 1) return []
+
+  if (totalPlayers === 5) {
+    return [1, 2, 3, 5, 4]
+  }
+
+  if (totalPlayers === 6) {
+    return [1, 2, 3, 6, 5, 4]
+  }
+
+  const rightEnd = Math.floor(totalPlayers / 2) + 1
+  const leftSeats = [1]
+  const rightSeats: number[] = []
+
+  for (let seat = totalPlayers; seat >= rightEnd + 1; seat -= 1) {
+    leftSeats.push(seat)
+  }
+  for (let seat = 2; seat <= rightEnd; seat += 1) {
+    rightSeats.push(seat)
+  }
+
+  const mirrored: number[] = []
+  const rows = Math.max(leftSeats.length, rightSeats.length)
+  for (let index = 0; index < rows; index += 1) {
+    if (leftSeats[index] !== undefined) mirrored.push(leftSeats[index])
+    if (rightSeats[index] !== undefined) mirrored.push(rightSeats[index])
+  }
+  return mirrored
+}
+
+interface LiveGamePageProps {
+  games: Game[]
+  userId: string
+  initialSession?: LiveGameSession | null
+  prefillCommander?: string
+  onSave: (game: Game) => void
+  onCancel: () => void
+  onDirtyChange?: (dirty: boolean) => void
+  onSessionStateChange?: (hasSession: boolean) => void
+}
+
+export function LiveGamePage({
+  games,
+  userId,
+  initialSession = null,
+  prefillCommander,
+  onSave,
+  onCancel,
+  onDirtyChange,
+  onSessionStateChange,
+}: LiveGamePageProps) {
+  const [isMobile, setIsMobile] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+  const [session, setSession] = useState<LiveGameSession | null>(initialSession)
+
+  const [playerCount, setPlayerCount] = useState<number | null>(null)
+  const [players, setPlayers] = useState<Partial<Player>[]>([])
+  const [notes, setNotes] = useState("")
+  const [winConditions, setWinConditions] = useState<string[]>([])
+  const [keyWinconCards, setKeyWinconCards] = useState<string[]>([])
+  const [bracket, setBracket] = useState<number | null>(null)
+  const [showBracketSelector, setShowBracketSelector] = useState(false)
+  const [errors, setErrors] = useState<SetupErrors>(EMPTY_SETUP_ERRORS)
+  const [finalizeError, setFinalizeError] = useState<string | null>(null)
+  const [copiedPayload, setCopiedPayload] = useState<"session" | "game" | null>(null)
+  const [commanderDamageExpandedByTarget, setCommanderDamageExpandedByTarget] = useState<Record<string, boolean>>({})
+  const [commanderDamageSourceByTarget, setCommanderDamageSourceByTarget] = useState<Record<string, string>>({})
+
+  // Draggable Next button
+  const [nextBtnPos, setNextBtnPos] = useState<{ x: number; y: number } | null>(null)
+  const dragState = useRef<{ startX: number; startY: number; originX: number; originY: number; moved: boolean } | null>(null)
+
+  function handleNextBtnPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
+    e.currentTarget.setPointerCapture(e.pointerId)
+    const origin = nextBtnPos ?? getDefaultNextBtnPos()
+    dragState.current = { startX: e.clientX, startY: e.clientY, originX: origin.x, originY: origin.y, moved: false }
+  }
+
+  function handleNextBtnPointerMove(e: React.PointerEvent<HTMLButtonElement>) {
+    if (!dragState.current) return
+    const dx = e.clientX - dragState.current.startX
+    const dy = e.clientY - dragState.current.startY
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) dragState.current.moved = true
+    setNextBtnPos({ x: dragState.current.originX + dx, y: dragState.current.originY + dy })
+  }
+
+  function handleNextBtnPointerUp(_e: React.PointerEvent<HTMLButtonElement>) {
+    const wasMoved = dragState.current?.moved ?? false
+    dragState.current = null
+    if (!wasMoved) handleAdvanceTurn()
+  }
+
+  function getDefaultNextBtnPos() {
+    return { x: window.innerWidth / 2 - 32, y: window.innerHeight / 2 - 32 }
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)")
+    const updateMobileState = () => setIsMobile(mediaQuery.matches)
+
+    updateMobileState()
+    mediaQuery.addEventListener("change", updateMobileState)
+    return () => mediaQuery.removeEventListener("change", updateMobileState)
+  }, [])
+
+  useEffect(() => {
+    if (!session) return
+    const interval = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(interval)
+  }, [session])
+
+  useEffect(() => {
+    if (!session) return
+    saveLiveGameSession(userId, session)
+    onSessionStateChange?.(true)
+  }, [onSessionStateChange, session, userId])
+
+  useEffect(() => {
+    if (!session) return
+    setNotes(session.notes ?? "")
+    setWinConditions(session.winConditions ?? [])
+    setKeyWinconCards(session.keyWinconCards ?? [])
+    setBracket(session.bracket ?? null)
+  }, [session])
+
+  const recentMyCommanders = useMemo((): RecentCommander[] => {
+    const seen = new Set<string>()
+    const result: RecentCommander[] = []
+    for (const game of games) {
+      const me = game.players.find((player) => player.isMe)
+      if (!me || seen.has(me.commanderName) || !me.commanderManaCost) continue
+      seen.add(me.commanderName)
+      result.push({
+        name: me.commanderName,
+        manaCost: me.commanderManaCost,
+        imageUri: me.commanderImageUri,
+        typeLine: me.commanderTypeLine,
+        colorIdentity: me.commanderColorIdentity,
+      })
+    }
+    return result
+  }, [games])
+
+  const knownPlayerNames = useMemo((): string[] => {
+    const names = new Set<string>()
+    for (const game of games) {
+      for (const player of game.players) {
+        if (!player.isMe && player.displayName?.trim()) {
+          names.add(player.displayName.trim())
+        }
+      }
+    }
+    return Array.from(names).sort((a, b) => a.localeCompare(b))
+  }, [games])
+
+  const pods = useMemo(() => {
+    const map = new Map<string, { id: string; opponents: string[]; label: string; totalPlayers: number }>()
+    for (const game of games) {
+      const names = game.players.map((player) => player.displayName?.trim()).filter(Boolean) as string[]
+      if (names.length !== game.players.length || names.length === 0) continue
+      const key = [...names].sort((a, b) => a.localeCompare(b)).join("|||")
+      if (!map.has(key)) {
+        const opponents = game.players
+          .filter((player) => !player.isMe)
+          .map((player) => player.displayName!.trim())
+          .sort((a, b) => a.localeCompare(b))
+        map.set(key, { id: key, opponents, label: opponents.join(", "), totalPlayers: game.players.length })
+      }
+    }
+    return Array.from(map.values())
+  }, [games])
+
+  const trackerGridColumns = (session?.players.length ?? 0) >= 5 ? 3 : 2
+  const trackerGridEntries = useMemo(() => {
+    const sessionPlayers = session?.players ?? []
+    const remainder = sessionPlayers.length % trackerGridColumns
+    if (remainder === 0) return sessionPlayers
+
+    const emptySlots = trackerGridColumns - remainder
+    return [...sessionPlayers, ...Array.from({ length: emptySlots }, () => null)]
+  }, [session?.players, trackerGridColumns])
+
+  const setupTotalPlayers = playerCount ?? 0
+  const setupGridColumns = setupTotalPlayers >= 5 ? 3 : 2
+  const setupMirroredSeatIndex = useMemo(() => {
+    const mirroredOrder = getMirroredSeatOrder(setupTotalPlayers)
+    return new Map(mirroredOrder.map((seat, index) => [seat, index]))
+  }, [setupTotalPlayers])
+
+  const sortedSetupPlayerEntries = useMemo(() => {
+    if (isMobile) {
+      return players.map((player, originalIndex) => ({ player, originalIndex }))
+    }
+
+    const seatByPlayerId = new Map<string, number>()
+    const assignedSeats = players
+      .map((player) => player.seatPosition)
+      .filter((seat): seat is SeatPosition => seat !== undefined)
+    const assignedSeatSet = new Set(assignedSeats)
+    const allPossibleSeats: SeatPosition[] = [1, 2, 3, 4, 5, 6]
+    const remainingSeats: SeatPosition[] = []
+
+    for (const seat of allPossibleSeats.slice(0, setupTotalPlayers)) {
+      if (!assignedSeatSet.has(seat)) {
+        remainingSeats.push(seat)
+      }
+    }
+
+    let remainingSeatIndex = 0
+    for (const player of players) {
+      const playerId = player.id
+      if (!playerId) continue
+      if (player.seatPosition !== undefined) {
+        seatByPlayerId.set(playerId, player.seatPosition)
+      } else {
+        const fallbackSeat = remainingSeats[remainingSeatIndex] ?? setupTotalPlayers
+        seatByPlayerId.set(playerId, fallbackSeat)
+        remainingSeatIndex += 1
+      }
+    }
+
+    return players
+      .map((player, originalIndex) => ({ player, originalIndex }))
+      .sort((a, b) => {
+        const aSeat = a.player.id ? seatByPlayerId.get(a.player.id) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER
+        const bSeat = b.player.id ? seatByPlayerId.get(b.player.id) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER
+        const aPosition = setupMirroredSeatIndex.get(aSeat) ?? Number.MAX_SAFE_INTEGER
+        const bPosition = setupMirroredSeatIndex.get(bSeat) ?? Number.MAX_SAFE_INTEGER
+        return aPosition - bPosition || a.originalIndex - b.originalIndex
+      })
+  }, [isMobile, players, setupMirroredSeatIndex, setupTotalPlayers])
+
+  const setupPlayerGridEntries = useMemo(() => {
+    if (isMobile) return sortedSetupPlayerEntries
+
+    const remainder = sortedSetupPlayerEntries.length % setupGridColumns
+    if (remainder === 0) return sortedSetupPlayerEntries
+
+    const emptySlots = setupGridColumns - remainder
+    const tailStart = sortedSetupPlayerEntries.length - remainder
+    return [
+      ...sortedSetupPlayerEntries.slice(0, tailStart),
+      ...Array.from({ length: emptySlots }, () => null),
+      ...sortedSetupPlayerEntries.slice(tailStart),
+    ]
+  }, [isMobile, setupGridColumns, sortedSetupPlayerEntries])
+
+  const hasSetupDetails = players.some((player) =>
+    Boolean(
+      player.commanderName?.trim()
+      || player.seatPosition
+      || player.partnerName?.trim()
+      || player.fastMana?.hasFastMana
+      || (player.fastMana?.cards?.length ?? 0) > 0
+    )
+  )
+
+  useEffect(() => {
+    if (session) {
+      onDirtyChange?.(false)
+      return
+    }
+
+    const hasDirtySetup =
+      playerCount !== null
+      || notes.trim().length > 0
+      || keyWinconCards.length > 0
+      || winConditions.length > 0
+      || bracket !== null
+      || hasSetupDetails
+
+    onDirtyChange?.(hasDirtySetup)
+    return () => onDirtyChange?.(false)
+  }, [bracket, hasSetupDetails, keyWinconCards.length, notes, onDirtyChange, playerCount, session, winConditions.length])
+
+  function initPlayers(total: number) {
+    const prefill = prefillCommander
+    let newPlayers: Partial<Player>[]
+
+    if (players.length === 0) {
+      newPlayers = []
+      const profile = loadProfile()
+      for (let index = 0; index < total; index += 1) {
+        const player = makePlayer(index === 0)
+        if (index === 0 && prefill) {
+          player.commanderName = prefill
+        }
+        if (index === 0 && profile.displayName) {
+          player.displayName = profile.displayName
+        }
+        newPlayers.push(player)
+      }
+
+      if (prefill) {
+        fetchCardByName(prefill)
+          .then((card) => {
+            const uri = resolveArtCrop(card)
+            setPlayers((prev) => {
+              const next = [...prev]
+              if (next[0]) {
+                next[0] = {
+                  ...next[0],
+                  commanderName: prefill,
+                  commanderImageUri: uri ?? undefined,
+                  commanderManaCost: card.mana_cost ?? card.card_faces?.[0]?.mana_cost,
+                  commanderTypeLine: card.type_line,
+                  commanderColorIdentity: card.color_identity as Player["commanderColorIdentity"],
+                }
+              }
+              return next
+            })
+          })
+          .catch(() => {})
+      }
+    } else if (total > players.length) {
+      newPlayers = [...players]
+      for (let index = players.length; index < total; index += 1) {
+        newPlayers.push(makePlayer(false))
+      }
+    } else {
+      newPlayers = players.slice(0, total).map((player) => ({
+        ...player,
+        seatPosition: player.seatPosition !== undefined && player.seatPosition <= total ? player.seatPosition : undefined,
+      }))
+    }
+
+    setPlayerCount(total)
+    setPlayers(newPlayers)
+    setErrors(EMPTY_SETUP_ERRORS)
+  }
+
+  function updatePlayer(index: number, updated: Partial<Player>) {
+    setPlayers((prev) => prev.map((player, playerIndex) => (playerIndex === index ? { ...player, ...updated } : player)))
+  }
+
+  function takenSeats(excludeIndex: number): SeatPosition[] {
+    return players
+      .filter((_, index) => index !== excludeIndex)
+      .map((player) => player.seatPosition)
+      .filter((seat): seat is SeatPosition => seat !== undefined)
+  }
+
+  function applyPod(podId: string) {
+    const pod = pods.find((entry) => entry.id === podId)
+    if (!pod) return
+
+    const total = pod.totalPlayers
+    const profile = loadProfile()
+    const meExisting = players[0]
+    const mePlayer: Partial<Player> = {
+      id: meExisting?.id ?? generateId(),
+      isMe: true,
+      displayName: profile.displayName || "",
+      commanderName: meExisting?.commanderName ?? (prefillCommander || undefined),
+      commanderImageUri: meExisting?.commanderImageUri,
+      commanderManaCost: meExisting?.commanderManaCost,
+      commanderTypeLine: meExisting?.commanderTypeLine,
+      commanderColorIdentity: meExisting?.commanderColorIdentity,
+      partnerName: meExisting?.partnerName,
+      partnerImageUri: meExisting?.partnerImageUri,
+      fastMana: meExisting?.fastMana ?? { hasFastMana: false, cards: [] },
+      seatPosition: meExisting?.seatPosition,
+    }
+    const opponentPlayers: Partial<Player>[] = pod.opponents.map((name, index) => {
+      const existing = players[index + 1]
+      return {
+        id: existing?.id ?? generateId(),
+        isMe: false,
+        displayName: name,
+        commanderName: existing?.commanderName,
+        commanderImageUri: existing?.commanderImageUri,
+        commanderManaCost: existing?.commanderManaCost,
+        commanderTypeLine: existing?.commanderTypeLine,
+        commanderColorIdentity: existing?.commanderColorIdentity,
+        partnerName: existing?.partnerName,
+        partnerImageUri: existing?.partnerImageUri,
+        fastMana: existing?.fastMana ?? { hasFastMana: false, cards: [] },
+        seatPosition: existing?.seatPosition,
+      }
+    })
+
+    setPlayerCount(total)
+    setPlayers([mePlayer, ...opponentPlayers])
+  }
+
+  function validateSetup() {
+    const seatCounts = new Map<number, number>()
+    players.forEach((player) => {
+      if (player.seatPosition) {
+        seatCounts.set(player.seatPosition, (seatCounts.get(player.seatPosition) ?? 0) + 1)
+      }
+    })
+
+    const nextErrors: SetupErrors = {
+      playerCount: !playerCount,
+      players: players.map((player) => ({
+        commanderName: !player.commanderName?.trim(),
+        seatPosition: !player.seatPosition || (seatCounts.get(player.seatPosition) ?? 0) > 1,
+      })),
+    }
+
+    const hasError = nextErrors.playerCount || nextErrors.players.some((player) => player.commanderName || player.seatPosition)
+    setErrors(hasError ? nextErrors : EMPTY_SETUP_ERRORS)
+    return !hasError
+  }
+
+  function handleStartTracking() {
+    if (!validateSetup()) return
+    const finalizedPlayers = players as Player[]
+    const turnOrder = [...finalizedPlayers].sort((a, b) => a.seatPosition - b.seatPosition)
+    const startingPlayerId = turnOrder[0]?.id
+    if (!startingPlayerId) return
+
+    const nextSession = buildLiveGameSession({
+      players: finalizedPlayers,
+      startingPlayerId,
+      bracket: bracket ?? undefined,
+    })
+
+    setSession(nextSession)
+    setFinalizeError(null)
+    onSessionStateChange?.(true)
+  }
+
+  function handleAdjustCounter(playerId: string, type: "life" | "poison", delta: number) {
+    setSession((prev) => {
+      if (!prev) return prev
+      return changePlayerCounter(prev, playerId, type, delta)
+    })
+  }
+
+  function handleAdjustCommanderDamage(targetPlayerId: string, sourcePlayerId: string, delta: number) {
+    setSession((prev) => {
+      if (!prev) return prev
+      return changeCommanderDamage(prev, targetPlayerId, sourcePlayerId, delta)
+    })
+  }
+
+  function handleAdvanceTurn() {
+    setSession((prev) => {
+      if (!prev) return prev
+      return advanceLiveGameTurn(prev)
+    })
+  }
+
+  function handleToggleEliminated(playerId: string, isEliminated: boolean) {
+    setSession((prev) => {
+      if (!prev) return prev
+      return setPlayerEliminated(prev, playerId, isEliminated)
+    })
+  }
+
+  function handleEnterFinalize() {
+    setSession((prev) => {
+      if (!prev) return prev
+      return prepareLiveGameForFinalize(prev)
+    })
+  }
+
+  function handleFinalizePatch(patch: Partial<Pick<LiveGameSession, "winnerId" | "winTurn" | "notes" | "winConditions" | "keyWinconCards">>) {
+    setSession((prev) => {
+      if (!prev) return prev
+      return updateLiveGameFinalization(prev, {
+        winnerId: patch.winnerId ?? prev.winnerId,
+        winTurn: patch.winTurn ?? prev.winTurn,
+        notes: patch.notes ?? prev.notes,
+        winConditions: patch.winConditions ?? prev.winConditions,
+        keyWinconCards: patch.keyWinconCards ?? prev.keyWinconCards,
+      })
+    })
+  }
+
+  function handleSaveFinalizedGame() {
+    if (!session) return
+    if (!session.winnerId) {
+      setFinalizeError("Choose a winner before saving.")
+      return
+    }
+    if (!session.winTurn || session.winTurn < 1) {
+      setFinalizeError("Enter a valid win turn.")
+      return
+    }
+
+    const game = buildGameFromLiveSession(session)
+    clearLiveGameSession(userId)
+    onSessionStateChange?.(false)
+    onSave(game)
+  }
+
+  function handleReturnToTracking() {
+    setSession((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        stage: "tracking",
+        updatedAt: new Date().toISOString(),
+      }
+    })
+  }
+
+  function copyPayload(kind: "session" | "game", payload: unknown) {
+    void (async () => {
+      try {
+        await navigator.clipboard.writeText(JSON.stringify(payload, null, 2))
+        setCopiedPayload(kind)
+        window.setTimeout(() => {
+          setCopiedPayload((prev) => (prev === kind ? null : prev))
+        }, 1600)
+      } catch {
+        setFinalizeError("Could not copy payload. Please copy from the preview text.")
+      }
+    })()
+  }
+
+  const setupErrorMessage = "Please fill in all highlighted setup fields."
+
+  if (!session) {
+    return (
+      <div className="space-y-6 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]">
+        <div className="space-y-2">
+          <h2 className={cn("text-sm font-semibold uppercase tracking-wide", errors.playerCount ? "text-destructive" : "text-muted-foreground")}>
+            How many players?
+          </h2>
+          <div className="flex gap-2">
+            {[2, 3, 4, 5, 6].map((count) => (
+              <Button
+                key={count}
+                type="button"
+                variant={playerCount === count ? "default" : "outline"}
+                className={cn("flex-1", errors.playerCount && playerCount !== count ? "border-destructive" : "")}
+                onClick={() => initPlayers(count)}
+              >
+                {count}
+              </Button>
+            ))}
+          </div>
+          {pods.length > 0 && (
+            <div className="flex flex-wrap gap-2 pt-2">
+              {pods.map((pod) => (
+                <Button key={pod.id} type="button" variant="outline" size="sm" onClick={() => applyPod(pod.id)}>
+                  {pod.label}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          {!showBracketSelector ? (
+            <Button type="button" variant="outline" onClick={() => setShowBracketSelector(true)} className="w-full">
+              Add game bracket (Optional)
+            </Button>
+          ) : (
+            <div className="flex gap-2">
+              {[1, 2, 3, 4, 5].map((count) => (
+                <Button key={count} type="button" variant={bracket === count ? "default" : "outline"} className="flex-1" onClick={() => setBracket(count)}>
+                  {count}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div
+          className={cn(
+            "overflow-hidden transition-all duration-300",
+            players.length > 0 ? "max-h-[260rem] opacity-100 translate-y-0" : "max-h-0 opacity-0 -translate-y-2 pointer-events-none"
+          )}
+          aria-hidden={players.length === 0}
+        >
+          <Separator />
+          <div className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Players</h2>
+            <div className={cn("grid gap-3", isMobile ? "grid-cols-1" : setupGridColumns === 3 ? "grid-cols-3" : "grid-cols-2")}>
+              {setupPlayerGridEntries.map((entry, gridIndex) => {
+                if (!entry) {
+                  return <div key={`setup-empty-slot-${gridIndex}`} aria-hidden="true" />
+                }
+
+                const { player, originalIndex } = entry
+                return (
+                  <PlayerRow
+                    key={player.id}
+                    player={player}
+                    isMe={player.isMe ?? false}
+                    playerOrder={originalIndex + 1}
+                    takenSeats={takenSeats(originalIndex)}
+                    totalPlayers={playerCount ?? 0}
+                    isWinner={false}
+                    showKoTurnControls={false}
+                    winTurn=""
+                    koTurn=""
+                    onSetWinner={() => {}}
+                    onWinTurnChange={() => {}}
+                    onKoTurnChange={() => {}}
+                    onChange={(updated) => updatePlayer(originalIndex, updated)}
+                    recentCommanders={player.isMe ? recentMyCommanders : undefined}
+                    knownPlayerNames={knownPlayerNames}
+                    fieldErrors={errors.players[originalIndex]}
+                    showOutcomeControls={false}
+                  />
+                )
+              })}
+            </div>
+          </div>
+
+        </div>
+
+        {errors.playerCount || errors.players.some((player) => player.commanderName || player.seatPosition) ? (
+          <div className="flex items-start gap-2 rounded-md border border-destructive bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{setupErrorMessage}</span>
+          </div>
+        ) : null}
+
+        <div className="flex gap-2 pt-2">
+          <Button variant="outline" className="flex-1" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button className="flex-1 gap-2" onClick={handleStartTracking} disabled={players.length === 0}>
+            <Play className="h-4 w-4" />
+            Start tracking
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (session.stage === "finalize") {
+    const debugGamePreview = buildGameFromLiveSession(session, now)
+    const eventsWithIndex = session.actions.map((action, index) => ({
+      eventIndex: index + 1,
+      ...action,
+    }))
+    const elapsedMsByPlayerId = Object.fromEntries(
+      session.players.map((player) => [player.id, getLiveGamePlayerElapsedMs(session, player.id, now)])
+    )
+    const alivePlayerIds = session.players.filter((player) => !player.isEliminated).map((player) => player.id)
+    const outPlayerIds = session.players.filter((player) => player.isEliminated).map((player) => player.id)
+    const debugSessionPreview = {
+      meta: {
+        createdAt: session.startedAt,
+        lastUpdatedAt: session.updatedAt,
+        actionCount: session.actions.length,
+      },
+      sessionState: {
+        turnNumber: session.turnNumber,
+        activePlayerId: session.activePlayerId,
+        startedAt: session.startedAt,
+        durationMs: getLiveGameDurationMs(session, now),
+      },
+      playersById: Object.fromEntries(
+        session.players.map((player) => [player.id, { name: player.displayName?.trim() || player.commanderName }])
+      ),
+      countersSnapshot: {
+        lifeByPlayerId: Object.fromEntries(session.players.map((player) => [player.id, player.lifeTotal])),
+        poisonByPlayerId: Object.fromEntries(session.players.map((player) => [player.id, player.poisonCounters])),
+        commanderDamageTakenByTarget: Object.fromEntries(
+          session.players.map((player) => [player.id, player.commanderDamageTakenByPlayerId])
+        ),
+        elapsedMsByPlayerId,
+        eliminationByPlayerId: Object.fromEntries(
+          session.players.map((player) => [
+            player.id,
+            player.isEliminated ? { turn: player.eliminatedAtTurn ?? session.turnNumber } : null,
+          ])
+        ),
+      },
+      events: eventsWithIndex,
+      derivedSummary: {
+        alivePlayerIds,
+        outPlayerIds,
+        elapsedMsTotal: Object.values(elapsedMsByPlayerId).reduce((sum, value) => sum + value, 0),
+      },
+    }
+
+    return (
+      <div className="space-y-6 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]">
+        <div className="space-y-2">
+          <Badge variant="secondary" className="w-fit">Turn {session.turnNumber}</Badge>
+          <h2 className="text-lg font-semibold">Finish the live game</h2>
+          <p className="text-sm text-muted-foreground">Pick the winner, confirm the win turn, and add the normal win details before saving.</p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-muted-foreground">Winner</label>
+          <div className="flex flex-wrap gap-2">
+            {session.players.map((player) => (
+              <Button
+                key={player.id}
+                type="button"
+                variant={session.winnerId === player.id ? "default" : "outline"}
+                onClick={() => {
+                  setFinalizeError(null)
+                  handleFinalizePatch({ winnerId: player.id })
+                }}
+              >
+                {player.displayName?.trim() || player.commanderName}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-muted-foreground">Win turn</label>
+          <Input
+            type="number"
+            min={1}
+            value={session.winTurn ?? session.turnNumber}
+            onChange={(event) => {
+              setFinalizeError(null)
+              handleFinalizePatch({ winTurn: Number.parseInt(event.target.value || "0", 10) || 0 })
+            }}
+          />
+        </div>
+
+        <Separator />
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs uppercase tracking-wide text-muted-foreground">Key wincon cards (Optional)</label>
+          </div>
+          <CardSearch
+            selectedCards={keyWinconCards}
+            onAddCard={(cardName) => {
+              const next = [...keyWinconCards, cardName]
+              setKeyWinconCards(next)
+              handleFinalizePatch({ keyWinconCards: next })
+            }}
+            onRemoveCard={(cardName) => {
+              const next = keyWinconCards.filter((card) => card !== cardName)
+              setKeyWinconCards(next)
+              handleFinalizePatch({ keyWinconCards: next })
+            }}
+            placeholder="Search for key wincon cards…"
+          />
+        </div>
+
+        <Separator />
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs uppercase tracking-wide text-muted-foreground">How did they win (Optional)</label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {WIN_CONDITION_CATEGORIES.map((condition) => (
+              <button
+                key={condition}
+                type="button"
+                onClick={() => {
+                  const next = winConditions.includes(condition)
+                    ? winConditions.filter((entry) => entry !== condition)
+                    : [...winConditions, condition]
+                  setWinConditions(next)
+                  handleFinalizePatch({ winConditions: next })
+                }}
+                className={cn(
+                  "rounded-md border px-3 py-2 text-xs transition-colors whitespace-nowrap",
+                  winConditions.includes(condition)
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background text-muted-foreground hover:bg-muted"
+                )}
+              >
+                {condition}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <Separator />
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-muted-foreground">Debug JSON preview</label>
+          <details className="rounded-md border bg-muted/20 p-3">
+            <summary className="cursor-pointer text-sm font-medium">Preview live session payload</summary>
+            <div className="mt-2 flex justify-end">
+              <Button type="button" size="sm" variant="outline" onClick={() => copyPayload("session", debugSessionPreview)}>
+                {copiedPayload === "session" ? "Copied" : "Copy"}
+              </Button>
+            </div>
+            <pre className="mt-2 max-h-64 overflow-auto rounded bg-background p-2 text-xs">{JSON.stringify(debugSessionPreview, null, 2)}</pre>
+          </details>
+          <details className="rounded-md border bg-muted/20 p-3">
+            <summary className="cursor-pointer text-sm font-medium">Preview final saved game payload</summary>
+            <div className="mt-2 flex justify-end">
+              <Button type="button" size="sm" variant="outline" onClick={() => copyPayload("game", debugGamePreview)}>
+                {copiedPayload === "game" ? "Copied" : "Copy"}
+              </Button>
+            </div>
+            <pre className="mt-2 max-h-64 overflow-auto rounded bg-background p-2 text-xs">{JSON.stringify(debugGamePreview, null, 2)}</pre>
+          </details>
+        </div>
+
+        <Separator />
+        <div className="space-y-1.5">
+          <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="live-notes">
+            Notes (Optional)
+          </label>
+          <Textarea
+            id="live-notes"
+            rows={3}
+            value={notes}
+            onChange={(event) => {
+              setNotes(event.target.value)
+              handleFinalizePatch({ notes: event.target.value })
+            }}
+            placeholder="Any additional notes…"
+          />
+        </div>
+
+        {finalizeError && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{finalizeError}</span>
+          </div>
+        )}
+
+        <div className="flex gap-2 pt-2">
+          <Button variant="outline" className="flex-1" onClick={handleReturnToTracking}>
+            Back to tracker
+          </Button>
+          <Button className="flex-1" onClick={handleSaveFinalizedGame}>
+            Save game
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  const totalDuration = getLiveGameDurationMs(session, now)
+  const activePlayer = session.players.find((player) => player.id === session.activePlayerId)
+
+  return (
+    <div className="space-y-4 pb-[calc(env(safe-area-inset-bottom)+4.5rem)]">
+      <div className="sticky top-0 z-10 -mx-4 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm font-semibold">
+            <Clock3 className="h-4 w-4 text-muted-foreground" />
+            <span>{formatDuration(totalDuration)}</span>
+          </div>
+          <Badge className="text-sm">Turn {session.turnNumber}</Badge>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Active player: <span className="font-medium text-foreground">{activePlayer?.displayName?.trim() || activePlayer?.commanderName}</span>
+        </p>
+      </div>
+
+      <div className={cn("grid gap-3", isMobile ? "grid-cols-1" : trackerGridColumns === 3 ? "grid-cols-3" : "grid-cols-2")}>
+        {trackerGridEntries.map((player, gridIndex) => {
+          if (!player) {
+            return <div key={`empty-slot-${gridIndex}`} aria-hidden="true" />
+          }
+
+          const isActive = player.id === session.activePlayerId
+          const elapsedMs = getLiveGamePlayerElapsedMs(session, player.id, now)
+          const isWinnerSelected = session.winnerId === player.id
+          const canReturnThisTurn = player.isEliminated && player.eliminatedAtTurn === session.turnNumber
+          return (
+            <Card key={player.id} className={cn("relative overflow-hidden", isActive ? "border-primary shadow-md" : "border-border", player.isEliminated ? "opacity-75" : "") }>
+              {player.commanderImageUri && (
+                <>
+                  <img
+                    src={player.commanderImageUri}
+                    alt={`${player.commanderName} art`}
+                    className="absolute inset-0 h-full w-full object-cover opacity-20"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-b from-background/30 via-background/70 to-background/95" />
+                </>
+              )}
+              <CardContent className="relative z-10 space-y-4 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h3 className="text-base font-semibold">{player.displayName?.trim() || player.commanderName}</h3>
+                      {isActive && <Badge variant="secondary">Active</Badge>}
+                      {isWinnerSelected && <Badge>Winner</Badge>}
+                      {player.isEliminated && <Badge variant="destructive">Out</Badge>}
+                    </div>
+                    <p className="text-sm text-muted-foreground">Seat {player.seatPosition} · {player.commanderName}{player.partnerName ? ` // ${player.partnerName}` : ""}</p>
+                  </div>
+                  <div className="text-right text-sm text-muted-foreground">
+                    <div>Clock</div>
+                    <div className="font-medium text-foreground">{formatDuration(elapsedMs)}</div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3">
+                  <div className="rounded-lg border bg-muted/30 p-3">
+                    <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Life</div>
+                    <div className="flex items-center justify-between gap-2">
+                      <Button type="button" variant="outline" size="sm" disabled={player.isEliminated} onClick={() => handleAdjustCounter(player.id, "life", -1)}>-</Button>
+                      <EditableNumber
+                        value={player.lifeTotal}
+                        disabled={player.isEliminated}
+                        className="text-3xl font-semibold tabular-nums"
+                        onCommit={(v) => handleAdjustCounter(player.id, "life", v - player.lifeTotal)}
+                      />
+                      <Button type="button" variant="outline" size="sm" onClick={() => handleAdjustCounter(player.id, "life", 1)}>+</Button>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {player.poisonCounters === 0 ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={player.isEliminated}
+                      onClick={() => handleAdjustCounter(player.id, "poison", 1)}
+                    >
+                      Add Poison
+                    </Button>
+                  ) : (
+                    <div className="inline-flex items-center gap-2 rounded-md border px-2 py-1">
+                      <span className="text-xs uppercase tracking-wide text-muted-foreground">Poison</span>
+                      <EditableNumber
+                        value={player.poisonCounters}
+                        disabled={player.isEliminated}
+                        className="text-sm font-semibold tabular-nums"
+                        onCommit={(v) => handleAdjustCounter(player.id, "poison", v - player.poisonCounters)}
+                      />
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="h-7 w-7 p-0"
+                        onClick={() => handleAdjustCounter(player.id, "poison", -1)}
+                      >
+                        -
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="h-7 w-7 p-0"
+                        disabled={player.isEliminated}
+                        onClick={() => handleAdjustCounter(player.id, "poison", 1)}
+                      >
+                        +
+                      </Button>
+                    </div>
+                  )}
+                  {(() => {
+                    const allSources = session.players.filter((candidate) => candidate.id !== player.id)
+                    const pickerOpen = commanderDamageExpandedByTarget[player.id] ?? false
+                    const pickerSource = commanderDamageSourceByTarget[player.id] ?? allSources[0]?.id ?? ""
+                    const existingEntries = Object.entries(player.commanderDamageTakenByPlayerId ?? {})
+
+                    return (
+                      <>
+                        {existingEntries.map(([sourceId, value]) => {
+                          const sourcePlayer = session.players.find((p) => p.id === sourceId)
+                          const sourceName = sourcePlayer?.displayName?.trim() || sourcePlayer?.commanderName || sourceId
+                          return (
+                            <div key={sourceId} className="inline-flex items-center gap-2 rounded-md border px-2 py-1">
+                              <span className="text-xs uppercase tracking-wide text-muted-foreground">Cmdr · {sourceName}</span>
+                              <EditableNumber
+                                value={value}
+                                disabled={player.isEliminated}
+                                className="text-sm font-semibold tabular-nums"
+                                onCommit={(v) => handleAdjustCommanderDamage(player.id, sourceId, v - value)}
+                              />
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="h-7 w-7 p-0"
+                                onClick={() => handleAdjustCommanderDamage(player.id, sourceId, -1)}
+                              >
+                                -
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="h-7 w-7 p-0"
+                                disabled={player.isEliminated}
+                                onClick={() => handleAdjustCommanderDamage(player.id, sourceId, 1)}
+                              >
+                                +
+                              </Button>
+                            </div>
+                          )
+                        })}
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          disabled={player.isEliminated}
+                          onClick={() => setCommanderDamageExpandedByTarget((prev) => ({ ...prev, [player.id]: !prev[player.id] }))}
+                        >
+                          Add commander damage
+                        </Button>
+                        {pickerOpen && !player.isEliminated && (
+                          <div className="inline-flex items-center gap-2 rounded-md border px-2 py-1">
+                            <select
+                              value={pickerSource}
+                              onChange={(event) => {
+                                setCommanderDamageSourceByTarget((prev) => ({ ...prev, [player.id]: event.target.value }))
+                              }}
+                              className="h-7 rounded border bg-background px-2 text-xs"
+                            >
+                              {allSources.map((candidate) => (
+                                <option key={candidate.id} value={candidate.id}>
+                                  {candidate.displayName?.trim() || candidate.commanderName}
+                                </option>
+                              ))}
+                            </select>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="h-7 w-7 p-0"
+                              disabled={!pickerSource}
+                              onClick={() => {
+                                if (!pickerSource) return
+                                handleAdjustCommanderDamage(player.id, pickerSource, 1)
+                              }}
+                            >
+                              +
+                            </Button>
+                          </div>
+                        )}
+                      </>
+                    )
+                  })()}
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={player.isEliminated ? "outline" : "secondary"}
+                    className="gap-2"
+                    disabled={player.isEliminated && !canReturnThisTurn}
+                    onClick={() => handleToggleEliminated(player.id, !player.isEliminated)}
+                  >
+                    <Skull className="h-4 w-4" />
+                    {player.isEliminated ? (canReturnThisTurn ? "Back in game" : "Out") : "Mark out"}
+                  </Button>
+                  {player.eliminatedAtTurn && <Badge variant="outline">Out on turn {player.eliminatedAtTurn}</Badge>}
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+
+      <div className="fixed inset-x-0 bottom-0 z-20 border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="mx-auto flex max-w-5xl gap-2">
+          <Button variant="outline" className="flex-1" onClick={handleEnterFinalize}>
+            End game
+          </Button>
+        </div>
+      </div>
+
+      {/* Draggable floating Next button */}
+      {(() => {
+        const pos = nextBtnPos ?? getDefaultNextBtnPos()
+        return (
+          <button
+            type="button"
+            style={{ position: "fixed", left: pos.x, top: pos.y, touchAction: "none", zIndex: 50 }}
+            onPointerDown={handleNextBtnPointerDown}
+            onPointerMove={handleNextBtnPointerMove}
+            onPointerUp={handleNextBtnPointerUp}
+            className="flex h-16 w-16 select-none items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground shadow-xl ring-2 ring-background active:scale-95"
+          >
+            Next
+          </button>
+        )
+      })()}
+    </div>
+  )
+}

--- a/src/pages/LogGamePage.tsx
+++ b/src/pages/LogGamePage.tsx
@@ -9,7 +9,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Separator } from "@/components/ui/separator"
 import { PlayerRow } from "@/components/PlayerRow"
 import { CardSearch } from "@/components/CardSearch"
-import { useGames } from "@/hooks/useGames"
 import { hasInvalidKoTiming } from "@/lib/validation"
 import { cn } from "@/lib/utils"
 import type { Game, Player, RecentCommander, SeatPosition } from "@/types"
@@ -90,14 +89,14 @@ function getMirroredSeatOrder(totalPlayers: number): number[] {
 const EMPTY_ERRORS: FormErrors = { playerCount: false, players: [], noWinner: false, winTurn: false, koTiming: false }
 
 interface LogGamePageProps {
+  games: Game[]
   onSave: (game: Game) => void
   onCancel: () => void
   onDirtyChange?: (dirty: boolean) => void
   prefillCommander?: string
 }
 
-export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander }: LogGamePageProps) {
-  const { games } = useGames()
+export function LogGamePage({ games, onSave, onCancel, onDirtyChange, prefillCommander }: LogGamePageProps) {
   const [isMobile, setIsMobile] = useState(false)
 
   useEffect(() => {

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -4,6 +4,7 @@ import { Cell, Legend, Pie, PieChart, Sector } from "recharts"
 import { type PieSectorDataItem } from "recharts/types/polar/Pie"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { NewGameMenu } from "@/components/NewGameMenu"
 import {
   ChartContainer,
   ChartTooltip,
@@ -62,9 +63,12 @@ interface StatsPageProps {
   games: Game[]
   onNavigate: (path: string) => void
   onOpenLogGame: (commanderName?: string) => void
+  onOpenLiveGame: (commanderName?: string) => void
+  onResumeLiveGame: () => void
+  hasLiveGame?: boolean
 }
 
-export function StatsPage({ games, onNavigate, onOpenLogGame }: StatsPageProps) {
+export function StatsPage({ games, onNavigate, onOpenLogGame, onOpenLiveGame, onResumeLiveGame, hasLiveGame = false }: StatsPageProps) {
   const stats = useStats(games)
   const podEloGroups = useMemo(() => computePodElo(games), [games])
   const commanderElo = useMemo(() => computeCommanderElo(games), [games])
@@ -106,13 +110,21 @@ export function StatsPage({ games, onNavigate, onOpenLogGame }: StatsPageProps) 
             <p className="text-muted-foreground text-sm">No games logged yet.</p>
             <p className="text-muted-foreground text-xs mt-1">Log a game to see your stats here.</p>
           </div>
-          <Button onClick={() => onOpenLogGame()} className="gap-1.5">
-            <Plus className="h-4 w-4" />
-            Track a game
-            <kbd className="ml-0.5 text-[10px] font-mono bg-white/15 border border-white/25 px-1 py-0.5 rounded leading-none">
-              N
-            </kbd>
-          </Button>
+          <NewGameMenu
+            hasLiveGame={hasLiveGame}
+            onQuickLog={onOpenLogGame}
+            onStartLiveGame={onOpenLiveGame}
+            onResumeLiveGame={onResumeLiveGame}
+            trigger={
+              <Button className="gap-1.5">
+                <Plus className="h-4 w-4" />
+                Track a game
+                <kbd className="ml-0.5 text-[10px] font-mono bg-white/15 border border-white/25 px-1 py-0.5 rounded leading-none">
+                  N
+                </kbd>
+              </Button>
+            }
+          />
         </div>
       </div>
     )

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,4 +1,4 @@
-import type { Player } from "@/types"
+import type { LiveGameSummary, Player } from "@/types"
 
 // ─── Supabase Database Types ────────────────────────────────────────────────
 
@@ -8,16 +8,23 @@ export type DbPlayer = Omit<Player, "id" | "isMe"> & {
   is_me: boolean
 }
 
+export type DbLiveGameSummary = LiveGameSummary
+
 export interface GameRow {
   id: string
   user_id: string
   played_at: string
+  started_at: string | null
+  ended_at: string | null
+  duration_ms: number | null
+  starting_player_id: string | null
   win_turn: number
   winner_player_id: string
   notes: string | null
   win_conditions: string[] | null
   key_wincon_cards: string[] | null
   bracket: number | null
+  live_summary: DbLiveGameSummary | null
   players: DbPlayer[]
   created_at: string
   updated_at: string
@@ -27,23 +34,33 @@ export interface GameInsert {
   id?: string
   user_id?: string // set by RLS default
   played_at: string
+  started_at?: string | null
+  ended_at?: string | null
+  duration_ms?: number | null
+  starting_player_id?: string | null
   win_turn: number
   winner_player_id: string
   notes?: string | null
   win_conditions?: string[] | null
   key_wincon_cards?: string[] | null
   bracket?: number | null
+  live_summary?: DbLiveGameSummary | null
   players: DbPlayer[]
 }
 
 export interface GameUpdate {
   played_at?: string
+  started_at?: string | null
+  ended_at?: string | null
+  duration_ms?: number | null
+  starting_player_id?: string | null
   win_turn?: number
   winner_player_id?: string
   notes?: string | null
   win_conditions?: string[] | null
   key_wincon_cards?: string[] | null
   bracket?: number | null
+  live_summary?: DbLiveGameSummary | null
   players?: DbPlayer[]
   updated_at?: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,66 @@ export interface FastManaInfo {
   cards: string[]
 }
 
+export type LiveGameActionType = "life" | "poison" | "commander-damage"
+
+export interface LiveGameAction {
+  id: string
+  type: LiveGameActionType
+  turnNumber: number
+  actingPlayerId: string
+  targetPlayerId: string
+  sourcePlayerId?: string
+  delta: number
+  createdAt: string
+}
+
+export interface LiveGameTrackedPlayer extends Player {
+  lifeTotal: number
+  poisonCounters: number
+  commanderDamageTakenByPlayerId: Record<string, number>
+  elapsedMs: number
+  isEliminated: boolean
+  eliminatedAtTurn?: number
+}
+
+export interface LiveGameSetup {
+  players: Player[]
+  startingPlayerId: string
+  bracket?: number
+}
+
+export interface LiveGameSession {
+  id: string
+  stage: "tracking" | "finalize"
+  createdAt: string
+  updatedAt: string
+  startedAt: string
+  activePlayerStartedAt: string
+  turnNumber: number
+  startingPlayerId: string
+  activePlayerId: string
+  players: LiveGameTrackedPlayer[]
+  bracket?: number
+  actions: LiveGameAction[]
+  winnerId?: string
+  winTurn?: number
+  winConditions?: string[]
+  keyWinconCards?: string[]
+  notes?: string
+}
+
+export interface LiveGameSummary {
+  startedAt: string
+  endedAt: string
+  durationMs: number
+  startingPlayerId: string
+  playerElapsedMs: Record<string, number>
+  finalLifeTotals: Record<string, number>
+  finalPoisonCounters: Record<string, number>
+  finalCommanderDamageTakenByPlayerId: Record<string, Record<string, number>>
+  actions: LiveGameAction[]
+}
+
 export interface Player {
   id: string
   isMe: boolean
@@ -54,6 +114,7 @@ export interface Player {
   seatPosition: SeatPosition
   displayName?: string
   fastMana: FastManaInfo
+  commanderDamageTakenByPlayerId?: Record<string, number>
 }
 
 export interface Game {
@@ -68,6 +129,12 @@ export interface Game {
   keyWinconCards?: string[]
   bracket?: number // 1-5, optional power level bracket
   playerNames?: Record<string, string> // map of player id → display name (set when all names provided)
+  startedAt?: string
+  endedAt?: string
+  durationMs?: number
+  startingPlayerId?: string
+  liveSummary?: LiveGameSummary
+  isLocalOnly?: boolean
 }
 
 export interface Pod {

--- a/supabase/migrations/006_add_live_tracking_summary.sql
+++ b/supabase/migrations/006_add_live_tracking_summary.sql
@@ -1,0 +1,6 @@
+alter table public.games
+  add column if not exists started_at timestamptz,
+  add column if not exists ended_at timestamptz,
+  add column if not exists duration_ms bigint,
+  add column if not exists starting_player_id text,
+  add column if not exists live_summary jsonb;


### PR DESCRIPTION
## Summary
- add a local-first live game flow with setup, tracking, finalize, and save handling
- add commander damage, poison, elimination, and revival logic for live sessions
- wire live-game launch and resume entry points into nav, dashboard, and stats
- add storage and Supabase compatibility updates for live-game summary data
- add reducer tests covering lethal-condition elimination and revival

## Testing
- npm run test:ci -- src/lib/__tests__/liveGame.test.ts