### PR TITLE
feat: add live game tracker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,18 +23,26 @@ import { HistoryPage } from "@/pages/HistoryPage"
 import { SettingsPage } from "@/pages/SettingsPage"
 import { LoggedOutHomePage } from "@/pages/LoggedOutHomePage"
 import { ReleaseNotesModal } from "@/pages/ReleaseNotesPage"
+import { TrackGamePage } from "@/pages/TrackGamePage"
 import { useGames } from "@/hooks/useGames"
 import { trackGameLogged } from '@/lib/analytics'
 import { useAuth } from "@/hooks/useAuth"
-import type { Game } from "@/types"
+import type { Game, Player } from "@/types"
 
 type GameFlowMode = "log" | "edit"
+
+interface LivePrefillResult {
+  players: Partial<Player>[]
+  winTurn: number
+  winnerId?: string
+}
 
 interface GameFlowState {
   mode: GameFlowMode
   minimized: boolean
   editGameId?: string
   prefillCommander?: string
+  prefillLiveResult?: LivePrefillResult
 }
 
 type ThemeMode = "light" | "dark" | "system"
@@ -48,6 +56,7 @@ function App() {
   const [isLogGameDirty, setIsLogGameDirty] = useState(false)
   const [showDiscardLogDialog, setShowDiscardLogDialog] = useState(false)
   const [themeMode, setThemeMode] = useState<ThemeMode>("system")
+  const [liveGamePlayers, setLiveGamePlayers] = useState<Partial<Player>[] | null>(null)
   const [systemTheme, setSystemTheme] = useState<Theme>("light")
   const navigate = useNavigate()
   const location = useLocation()
@@ -58,6 +67,35 @@ function App() {
   const editingGame = gameFlow?.mode === "edit" && gameFlow.editGameId
     ? getGame(gameFlow.editGameId)
     : undefined
+
+  function openLiveGame(players: Partial<Player>[]) {
+    setLiveGamePlayers(players)
+    setGameFlow(null)
+  }
+
+  function closeLiveGame(result?: { winTurn: number; knockoutTurns: Record<string, number>; winnerId?: string }) {
+    const savedPlayers = liveGamePlayers
+    setLiveGamePlayers(null)
+
+    if (result && savedPlayers) {
+      // Reopen the log-game drawer pre-populated with the live session data
+      const updatedPlayers = savedPlayers.map((p) => ({
+        ...p,
+        knockoutTurn: p.id && result.knockoutTurns[p.id] ? result.knockoutTurns[p.id] : p.knockoutTurn,
+      }))
+      setIsLogGameDirty(false)
+      setGameFlow({
+        mode: "log",
+        minimized: false,
+        prefillCommander: updatedPlayers.find((p) => p.isMe)?.commanderName,
+        prefillLiveResult: {
+          players: updatedPlayers,
+          winTurn: result.winTurn,
+          winnerId: result.winnerId,
+        },
+      })
+    }
+  }
 
   function openLogGameFlow(prefillCommander?: string) {
     setIsLogGameDirty(false)
@@ -217,7 +255,18 @@ function App() {
           })()
         }}
       />
-      {/* Live game UI removed */}
+      {/* Live game tracker overlay */}
+      {liveGamePlayers && (
+        <TrackGamePage
+          players={liveGamePlayers}
+          onExit={closeLiveGame}
+          onRematch={() => {
+            const saved = liveGamePlayers
+            setLiveGamePlayers(null)
+            setTimeout(() => setLiveGamePlayers(saved), 50)
+          }}
+        />
+      )}
       <main className="container mx-auto max-w-5xl px-4 py-6">
         {gamesLoading ? (
           <div className="flex items-center justify-center py-20">
@@ -304,9 +353,11 @@ function App() {
           {gameFlow.mode === "log" ? (
             <LogGamePage
               prefillCommander={gameFlow.prefillCommander}
+              prefillLiveResult={gameFlow.prefillLiveResult}
               onSave={handleSaveGame}
               onCancel={handleCancelGameFlow}
               onDirtyChange={setIsLogGameDirty}
+              onTrackLive={openLiveGame}
             />
           ) : (
             editingGame && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { SettingsPage } from "@/pages/SettingsPage"
 import { LoggedOutHomePage } from "@/pages/LoggedOutHomePage"
 import { ReleaseNotesModal } from "@/pages/ReleaseNotesPage"
 import { TrackGamePage } from "@/pages/TrackGamePage"
+import { LiveAnnouncementModal, hasSeenLiveAnnouncement } from "@/components/LiveAnnouncementModal"
 import { useGames } from "@/hooks/useGames"
 import { trackGameLogged } from '@/lib/analytics'
 import { useAuth } from "@/hooks/useAuth"
@@ -57,6 +58,7 @@ function App() {
   const [showDiscardLogDialog, setShowDiscardLogDialog] = useState(false)
   const [themeMode, setThemeMode] = useState<ThemeMode>("system")
   const [liveGamePlayers, setLiveGamePlayers] = useState<Partial<Player>[] | null>(null)
+  const [showLiveAnnouncement, setShowLiveAnnouncement] = useState(() => !hasSeenLiveAnnouncement())
   const [systemTheme, setSystemTheme] = useState<Theme>("light")
   const navigate = useNavigate()
   const location = useLocation()
@@ -326,6 +328,7 @@ function App() {
         onToggleTheme={toggleTheme}
       />
       <ReleaseNotesModal open={showReleaseNotes} onOpenChange={setShowReleaseNotes} />
+      <LiveAnnouncementModal open={showLiveAnnouncement} onClose={() => setShowLiveAnnouncement(false)} />
 
       <AlertDialog open={showDiscardLogDialog} onOpenChange={setShowDiscardLogDialog}>
         <AlertDialogContent>

--- a/src/components/LiveAnnouncementModal.tsx
+++ b/src/components/LiveAnnouncementModal.tsx
@@ -1,0 +1,76 @@
+import { Swords, FlaskConical } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+const STORAGE_KEY = "eda_seen_live_announcement_v1"
+
+export function hasSeenLiveAnnouncement(): boolean {
+  return !!localStorage.getItem(STORAGE_KEY)
+}
+
+export function markLiveAnnouncementSeen(): void {
+  localStorage.setItem(STORAGE_KEY, "1")
+}
+
+interface LiveAnnouncementModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function LiveAnnouncementModal({ open, onClose }: LiveAnnouncementModalProps) {
+  function handleClose() {
+    markLiveAnnouncementSeen()
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose() }}>
+      <DialogContent className="max-w-sm [&>button:last-child]:hidden">
+        <DialogHeader className="items-center text-center gap-3">
+          <div className="w-16 h-16 rounded-full bg-primary/10 border-2 border-primary flex items-center justify-center">
+            <Swords className="h-8 w-8 text-primary" />
+          </div>
+          <div>
+            <DialogTitle className="text-xl leading-tight">
+              Live Game Tracking is here
+            </DialogTitle>
+            <DialogDescription className="mt-1.5 text-sm">
+              Track a Commander game in real time — life totals, turn timer,
+              drag-to-deal damage, commander damage per player, and poison
+              counters. When the game ends, your data flows straight into
+              the log form.
+            </DialogDescription>
+          </div>
+        </DialogHeader>
+
+        {/* Experimental warning */}
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-3">
+          <FlaskConical className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+          <div className="text-xs text-amber-600 dark:text-amber-400 leading-relaxed">
+            <span className="font-bold">Highly experimental.</span> The tracker
+            may have bugs or unexpected behaviour. Use at your own risk — always
+            double-check life totals before logging.
+          </div>
+        </div>
+
+        <p className="text-xs text-muted-foreground text-center leading-relaxed">
+          To start a tracked game, open{" "}
+          <span className="font-semibold text-foreground">Log Game</span> and
+          tap{" "}
+          <span className="font-semibold text-foreground">Track Game Live</span>{" "}
+          after selecting your players.
+        </p>
+
+        <Button className="w-full" onClick={handleClose}>
+          Got it
+        </Button>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/LiveAnnouncementModal.tsx
+++ b/src/components/LiveAnnouncementModal.tsx
@@ -41,10 +41,7 @@ export function LiveAnnouncementModal({ open, onClose }: LiveAnnouncementModalPr
               Live Game Tracking is here
             </DialogTitle>
             <DialogDescription className="mt-1.5 text-sm">
-              Track a Commander game in real time — life totals, turn timer,
-              drag-to-deal damage, commander damage per player, and poison
-              counters. When the game ends, your data flows straight into
-              the log form.
+              You can now use this app to track games live. All game events created will be logged, allowing for many more interesting features in the future. Look forward to your feedback!
             </DialogDescription>
           </div>
         </DialogHeader>
@@ -54,8 +51,7 @@ export function LiveAnnouncementModal({ open, onClose }: LiveAnnouncementModalPr
           <FlaskConical className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
           <div className="text-xs text-amber-600 dark:text-amber-400 leading-relaxed">
             <span className="font-bold">Highly experimental.</span> The tracker
-            may have bugs or unexpected behaviour. Use at your own risk — always
-            double-check life totals before logging.
+            may have bugs or unexpected behaviour.
           </div>
         </div>
 

--- a/src/components/live/DamageSheet.tsx
+++ b/src/components/live/DamageSheet.tsx
@@ -1,0 +1,193 @@
+import { useRef } from "react"
+import { Minus, Plus } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import type { LivePlayer, DamageSheetState } from "@/types/live"
+
+const LONG_PRESS_MS = 400
+
+interface DamageSheetProps {
+  sheet: DamageSheetState
+  players: LivePlayer[]
+  onApply: () => void
+  onCancel: () => void
+  onUpdateAmount: (amount: number) => void
+  onUpdateType: (damageType: "regular" | "commander") => void
+  onUpdateLifelink: (lifelink: boolean) => void
+}
+
+function AmountButton({
+  onPress,
+  onLongPress,
+  children,
+}: {
+  onPress: () => void
+  onLongPress: () => void
+  children: React.ReactNode
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const firedRef = useRef(false)
+
+  function start() {
+    firedRef.current = false
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true
+      onLongPress()
+    }, LONG_PRESS_MS)
+  }
+  function end() {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (!firedRef.current) onPress()
+  }
+  function cancel() {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    firedRef.current = true
+  }
+
+  return (
+    <button
+      className="w-12 h-12 rounded-full border bg-muted hover:bg-accent flex items-center justify-center active:scale-90 transition-transform select-none touch-none"
+      onPointerDown={start}
+      onPointerUp={end}
+      onPointerLeave={cancel}
+      onPointerCancel={cancel}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function DamageSheet({ sheet, players, onApply, onCancel, onUpdateAmount, onUpdateType, onUpdateLifelink }: DamageSheetProps) {
+  const source = players.find((p) => p.id === sheet.sourcePlayerId)
+  const target = players.find((p) => p.id === sheet.targetPlayerId)
+
+  const sourceLabel = source ? (source.displayName || source.commanderName) : "Unknown"
+  const targetLabel = target ? (target.displayName || target.commanderName) : "Unknown"
+
+  const isCommander = sheet.damageType === "commander"
+
+  function adjust(delta: number) {
+    onUpdateAmount(Math.max(1, sheet.amount + delta))
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onCancel() }}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>
+            Damage to <span className="text-destructive">{targetLabel}</span>
+          </DialogTitle>
+          <DialogDescription>From {sourceLabel}</DialogDescription>
+        </DialogHeader>
+
+        <Separator />
+
+        {/* Amount picker */}
+        <div className="flex items-center justify-center gap-6 py-2">
+          <AmountButton onPress={() => adjust(-1)} onLongPress={() => adjust(-5)}>
+            <Minus className="h-4 w-4" />
+          </AmountButton>
+          <span className="text-6xl font-black tabular-nums min-w-[3ch] text-center leading-none">
+            {sheet.amount}
+          </span>
+          <AmountButton onPress={() => adjust(1)} onLongPress={() => adjust(5)}>
+            <Plus className="h-4 w-4" />
+          </AmountButton>
+        </div>
+
+        <p className="text-center text-xs text-muted-foreground -mt-1">
+          Hold +/− to adjust by 5
+        </p>
+
+        <Separator />
+
+        {/* Commander damage checkbox */}
+        <button
+          onClick={() => onUpdateType(isCommander ? "regular" : "commander")}
+          className={cn(
+            "w-full flex items-center gap-3 px-3 py-3 rounded-lg border text-left transition-colors",
+            isCommander
+              ? "bg-accent border-primary"
+              : "bg-background border-input hover:bg-accent"
+          )}
+        >
+          <div
+            className={cn(
+              "w-4 h-4 rounded border-2 flex items-center justify-center shrink-0 transition-colors",
+              isCommander ? "bg-primary border-primary" : "border-muted-foreground"
+            )}
+          >
+            {isCommander && (
+              <svg viewBox="0 0 12 10" className="w-2.5 h-2.5 fill-none stroke-primary-foreground stroke-[2.5]">
+                <polyline points="1,5 4,8 11,1" />
+              </svg>
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">Commander damage</p>
+            {(() => {
+              const existing = target ? (target.commanderDamageReceived[sheet.sourcePlayerId] ?? 0) : 0
+              return existing > 0 ? (
+                <p className="text-xs text-orange-400 font-semibold tabular-nums">
+                  {existing}/21 already from {sourceLabel}
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">Counts toward 21-damage loss</p>
+              )
+            })()}
+          </div>
+        </button>
+
+        {/* Lifelink checkbox */}
+        <button
+          onClick={() => onUpdateLifelink(!sheet.lifelink)}
+          className={cn(
+            "w-full flex items-center gap-3 px-3 py-3 rounded-lg border text-left transition-colors",
+            sheet.lifelink
+              ? "bg-accent border-primary"
+              : "bg-background border-input hover:bg-accent"
+          )}
+        >
+          <div
+            className={cn(
+              "w-4 h-4 rounded border-2 flex items-center justify-center shrink-0 transition-colors",
+              sheet.lifelink ? "bg-primary border-primary" : "border-muted-foreground"
+            )}
+          >
+            {sheet.lifelink && (
+              <svg viewBox="0 0 12 10" className="w-2.5 h-2.5 fill-none stroke-primary-foreground stroke-[2.5]">
+                <polyline points="1,5 4,8 11,1" />
+              </svg>
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">Lifelink</p>
+            <p className="text-xs text-muted-foreground">{sourceLabel} gains {sheet.amount} life</p>
+          </div>
+        </button>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="outline" className="flex-1" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant={isCommander ? "default" : "destructive"}
+            className="flex-1"
+            onClick={onApply}
+          >
+            Apply −{sheet.amount}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/live/PlayerTile.tsx
+++ b/src/components/live/PlayerTile.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useRef, useState } from "react"
+import { Minus, Plus, Skull, Swords } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { LivePlayer } from "@/types/live"
+
+const PLAYER_COLORS = [
+  { border: "border-blue-500", bg: "bg-blue-950/60", glow: "shadow-blue-500/40", dot: "bg-blue-400", badge: "bg-blue-500" },
+  { border: "border-red-500",  bg: "bg-red-950/60",  glow: "shadow-red-500/40",  dot: "bg-red-400",  badge: "bg-red-500" },
+  { border: "border-green-500", bg: "bg-green-950/60", glow: "shadow-green-500/40", dot: "bg-green-400", badge: "bg-green-500" },
+  { border: "border-yellow-500", bg: "bg-yellow-950/60", glow: "shadow-yellow-500/40", dot: "bg-yellow-400", badge: "bg-yellow-500" },
+  { border: "border-purple-500", bg: "bg-purple-950/60", glow: "shadow-purple-500/40", dot: "bg-purple-400", badge: "bg-purple-500" },
+]
+
+export function playerColor(index: number) {
+  return PLAYER_COLORS[index % PLAYER_COLORS.length]
+}
+
+interface PlayerTileProps {
+  player: LivePlayer
+  playerIndex: number
+  rotation: number
+  isActive: boolean
+  isDragActive: boolean
+  isDragSource: boolean
+  isDropTarget: boolean
+  allPlayers: LivePlayer[]
+  onAdjustDelta: (delta: number) => void
+  onAvatarPointerDown: (e: React.PointerEvent) => void
+  onAdjustPoison: (delta: number) => void
+}
+
+const LONG_PRESS_MS = 500
+
+function LongPressButton({
+  onPress,
+  onLongPress,
+  className,
+  children,
+}: {
+  onPress: () => void
+  onLongPress: () => void
+  className?: string
+  children: React.ReactNode
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const firedRef = useRef(false)
+
+  function start() {
+    firedRef.current = false
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true
+      onLongPress()
+    }, LONG_PRESS_MS)
+  }
+
+  function end() {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (!firedRef.current) onPress()
+  }
+
+  function cancel() {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    firedRef.current = true
+  }
+
+  return (
+    <button
+      className={cn("select-none touch-none active:scale-90 transition-transform", className)}
+      onPointerDown={start}
+      onPointerUp={end}
+      onPointerLeave={cancel}
+      onPointerCancel={cancel}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function PlayerTile({
+  player,
+  playerIndex,
+  rotation,
+  isActive,
+  isDragActive,
+  isDragSource,
+  isDropTarget,
+  allPlayers,
+  onAdjustDelta,
+  onAvatarPointerDown,
+  onAdjustPoison,
+}: PlayerTileProps) {
+  const color = playerColor(playerIndex)
+  const [showPoison, setShowPoison] = useState(false)
+  const poisonTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Increment to remount the avatar div each time this player's turn begins,
+  // which forces the CSS animation to restart from frame 0.
+  const [avatarKey, setAvatarKey] = useState(0)
+  useEffect(() => {
+    if (isActive) setAvatarKey((k) => k + 1)
+  }, [isActive])
+
+  const label = player.displayName || player.commanderName
+
+  const lifeColor =
+    player.lifeTotal <= 5
+      ? "text-red-400"
+      : player.lifeTotal <= 10
+        ? "text-orange-400"
+        : player.lifeTotal > 40
+          ? "text-yellow-300"
+          : "text-white"
+
+  function handleHeaderLongPress() {
+    setShowPoison(true)
+    if (poisonTimerRef.current) clearTimeout(poisonTimerRef.current)
+    poisonTimerRef.current = setTimeout(() => setShowPoison(false), 4000)
+  }
+
+  function dismissPoison() {
+    if (poisonTimerRef.current) clearTimeout(poisonTimerRef.current)
+    setShowPoison(false)
+  }
+
+  const cmdDmgEntries = Object.entries(player.commanderDamageReceived).filter(([, v]) => v > 0)
+  const hasArt = !!player.commanderImageUri
+
+  return (
+    <div className="relative w-full h-full overflow-hidden rounded-2xl">
+      {/* Full-art commander background — rotated to face the seated player */}
+      {hasArt && (
+        <>
+          <img
+            src={player.commanderImageUri}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+            style={{ transform: `rotate(${rotation}deg)` }}
+            draggable={false}
+          />
+          {/* Symmetric gradient scrim — dark at both ends (name/buttons), lighter in center (life total) */}
+          <div className="absolute inset-0 bg-gradient-to-b from-black/75 via-black/45 to-black/75 pointer-events-none" />
+        </>
+      )}
+
+      {/* Main rotated content */}
+      <div
+        className={cn(
+          "w-full h-full flex flex-col items-center justify-between p-2 rounded-2xl border-2 select-none transition-all duration-200",
+          color.border,
+          hasArt ? "bg-transparent" : color.bg,
+          isActive && `shadow-lg ${color.glow}`,
+          isDragSource && "opacity-40",
+          player.isEliminated && "opacity-50"
+        )}
+        style={{ transform: `rotate(${rotation}deg)` }}
+      >
+        {/* Header: name + commander, long-press for poison */}
+        <LongPressButton
+          onPress={() => {}}
+          onLongPress={handleHeaderLongPress}
+          className="w-full text-center"
+        >
+          <p className="text-lg font-black leading-tight truncate max-w-full text-white drop-shadow-lg">{label}</p>
+          {player.commanderName && player.displayName && (
+            <p className="text-xs font-semibold leading-tight truncate max-w-full text-gray-300 uppercase tracking-wider drop-shadow">{player.commanderName}</p>
+          )}
+        </LongPressButton>
+
+        {/* Avatar — key changes each time isActive becomes true, restarting the bounce */}
+        <div
+          key={avatarKey}
+          className={cn(
+            "relative rounded-full overflow-hidden border-2 cursor-grab touch-none shrink-0",
+            color.border,
+            isActive && "ring-2 ring-white/50 live-avatar-bounce",
+            isDragActive && !isDragSource && "ring-2 ring-white/30"
+          )}
+          style={{ width: "min(14vmin, 72px)", height: "min(14vmin, 72px)" }}
+          onPointerDown={onAvatarPointerDown}
+          data-player-id={player.id}
+        >
+          {player.commanderImageUri ? (
+            <img
+              src={player.commanderImageUri}
+              alt={player.commanderName}
+              className="w-full h-full object-cover pointer-events-none"
+              draggable={false}
+            />
+          ) : (
+            <div className={cn("w-full h-full flex items-center justify-center", color.bg)}>
+              <span className="text-2xl font-bold text-white/60">
+                {player.commanderName.charAt(0).toUpperCase()}
+              </span>
+            </div>
+          )}
+
+          {/* Poison counter badge */}
+          {player.poisonCounters > 0 && (
+            <div className="absolute -top-1 -right-1 bg-green-600 text-white text-[9px] font-bold rounded-full w-4 h-4 flex items-center justify-center">
+              {player.poisonCounters}
+            </div>
+          )}
+
+          {isActive && (
+            <div className="absolute inset-0 rounded-full ring-4 ring-white/30 animate-pulse pointer-events-none" />
+          )}
+        </div>
+
+        {/* Life total + pending delta */}
+        <div className="relative flex items-center justify-center">
+          <span className={cn("font-black tabular-nums leading-none drop-shadow-lg", lifeColor, "text-5xl sm:text-6xl")}>
+            {player.lifeTotal}
+          </span>
+          {player.pendingDelta !== 0 && (
+            <span
+              className={cn(
+                "absolute -top-3 -right-6 text-sm font-bold px-1 rounded",
+                player.pendingDelta > 0 ? "text-green-400" : "text-red-400"
+              )}
+            >
+              {player.pendingDelta > 0 ? `+${player.pendingDelta}` : player.pendingDelta}
+            </span>
+          )}
+        </div>
+
+        {/* Per-source commander damage */}
+        {cmdDmgEntries.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap justify-center">
+            <Swords className="h-3 w-3 text-orange-400 shrink-0" />
+            {cmdDmgEntries.map(([sourceId, amount]) => {
+              const sourceIdx = allPlayers.findIndex((p) => p.id === sourceId)
+              const srcColor = playerColor(Math.max(0, sourceIdx))
+              return (
+                <div key={sourceId} className="flex items-center gap-0.5">
+                  <span className={cn("w-2 h-2 rounded-full shrink-0", srcColor.dot)} />
+                  <span className="text-[10px] font-bold text-orange-300 tabular-nums">{amount}</span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Plus / minus */}
+        <div className="flex items-center gap-3">
+          <LongPressButton
+            onPress={() => onAdjustDelta(-1)}
+            onLongPress={() => onAdjustDelta(-10)}
+            className="w-10 h-10 rounded-full bg-black/50 border border-white/20 flex items-center justify-center text-white hover:bg-black/70"
+          >
+            <Minus className="h-4 w-4" />
+          </LongPressButton>
+          <LongPressButton
+            onPress={() => onAdjustDelta(1)}
+            onLongPress={() => onAdjustDelta(10)}
+            className="w-10 h-10 rounded-full bg-black/50 border border-white/20 flex items-center justify-center text-white hover:bg-black/70"
+          >
+            <Plus className="h-4 w-4" />
+          </LongPressButton>
+        </div>
+      </div>
+
+      {/* Elimination overlay (not rotated) */}
+      {player.isEliminated && (
+        <div className="absolute inset-0 rounded-2xl bg-black/70 flex flex-col items-center justify-center z-10 pointer-events-none">
+          <Skull className="h-8 w-8 text-gray-400" />
+          <p className="text-gray-400 text-xs mt-1 font-medium">
+            Out T{player.eliminatedOnTurn ?? "?"}
+          </p>
+        </div>
+      )}
+
+      {/* Drop zone highlight */}
+      {isDragActive && !isDragSource && !player.isEliminated && (
+        <div
+          className={cn(
+            "absolute inset-0 rounded-2xl z-20 transition-all duration-150 pointer-events-none",
+            isDropTarget
+              ? "bg-red-500/25 border-2 border-red-400 scale-[1.03]"
+              : "bg-white/5 border-2 border-white/15"
+          )}
+        />
+      )}
+
+      {/* Poison overlay */}
+      {showPoison && (
+        <div className="absolute inset-0 z-30 flex items-center justify-center rounded-2xl bg-black/80 pointer-events-auto">
+          <div className="flex flex-col items-center gap-2">
+            <p className="text-green-400 text-xs font-bold uppercase tracking-wide">Poison</p>
+            <div className="flex items-center gap-3">
+              <button
+                className="w-9 h-9 rounded-full bg-gray-700 text-white text-xl flex items-center justify-center active:scale-90"
+                onClick={() => { onAdjustPoison(-1); dismissPoison() }}
+              >
+                −
+              </button>
+              <span className="text-3xl font-black text-green-400 tabular-nums w-8 text-center">
+                {player.poisonCounters}
+              </span>
+              <button
+                className="w-9 h-9 rounded-full bg-gray-700 text-white text-xl flex items-center justify-center active:scale-90"
+                onClick={() => { onAdjustPoison(1); dismissPoison() }}
+              >
+                +
+              </button>
+            </div>
+            <button className="text-gray-500 text-xs" onClick={dismissPoison}>Done</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/live/TurnHub.tsx
+++ b/src/components/live/TurnHub.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react"
+import { ChevronRight } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { LivePlayer } from "@/types/live"
+import { playerColor } from "./PlayerTile"
+
+interface TurnHubProps {
+  currentTurn: number
+  turnStartedAt: number
+  activeSeatIndex: number
+  players: LivePlayer[]
+  isDragging: boolean
+  onEndTurn: () => void
+}
+
+export function TurnHub({ currentTurn, turnStartedAt, activeSeatIndex, players, isDragging, onEndTurn }: TurnHubProps) {
+  const [elapsed, setElapsed] = useState(0)
+
+  useEffect(() => {
+    setElapsed(0)
+    const id = setInterval(() => setElapsed(Date.now() - turnStartedAt), 1000)
+    return () => clearInterval(id)
+  }, [turnStartedAt])
+
+  const minutes = Math.floor(elapsed / 60_000)
+  const seconds = Math.floor((elapsed % 60_000) / 1_000)
+  const timerStr = `${minutes}:${String(seconds).padStart(2, "0")}`
+
+  const timerColor =
+    elapsed >= 480_000 ? "text-red-400" :
+    elapsed >= 240_000 ? "text-amber-400" :
+    "text-gray-300"
+
+  const activePlayer = players[activeSeatIndex]
+  const activeLabel = activePlayer
+    ? (activePlayer.displayName || activePlayer.commanderName)
+    : ""
+
+  return (
+    <div className="flex flex-col items-center gap-2 bg-gray-900/95 rounded-2xl px-4 py-3 border border-gray-700 shadow-xl min-w-[150px] max-w-[210px] w-full">
+      {/* Turn order dots */}
+      <div className="flex gap-1.5 flex-wrap justify-center">
+        {players.map((p, i) => {
+          const color = playerColor(i)
+          return (
+            <div
+              key={p.id}
+              className={cn(
+                "w-2.5 h-2.5 rounded-full transition-all duration-300",
+                p.isEliminated
+                  ? "bg-gray-700"
+                  : i === activeSeatIndex
+                    ? cn(color.dot, "scale-125 shadow-sm")
+                    : "bg-gray-600"
+              )}
+              title={p.displayName || p.commanderName}
+            />
+          )
+        })}
+      </div>
+
+      {/* Turn info */}
+      <div className="text-center leading-tight">
+        <p className="text-[10px] text-gray-500 uppercase tracking-widest font-medium">Turn {currentTurn}</p>
+        <p className="text-sm font-semibold text-white truncate max-w-[170px]">{activeLabel}</p>
+        <p className={cn("font-mono text-xl font-bold tabular-nums", timerColor)}>{timerStr}</p>
+      </div>
+
+      {/* End Turn button */}
+      <button
+        onClick={onEndTurn}
+        disabled={isDragging}
+        className={cn(
+          "w-full flex items-center justify-center gap-1 py-2 rounded-xl font-bold text-sm transition-all duration-150",
+          isDragging
+            ? "bg-gray-700 text-gray-500 cursor-not-allowed"
+            : "bg-white text-gray-900 hover:bg-gray-100 active:scale-95 shadow-md"
+        )}
+      >
+        End Turn
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/live/WinnerOverlay.tsx
+++ b/src/components/live/WinnerOverlay.tsx
@@ -1,0 +1,102 @@
+import { Trophy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import type { LivePlayer, TurnLogEntry } from "@/types/live"
+
+interface WinnerOverlayProps {
+  winner: LivePlayer
+  players: LivePlayer[]
+  turnLog: TurnLogEntry[]
+  startedAt: number
+  currentTurn: number
+  onSave: () => void
+  onRematch: () => void
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const h = Math.floor(totalSeconds / 3600)
+  const m = Math.floor((totalSeconds % 3600) / 60)
+  const s = totalSeconds % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+export function WinnerOverlay({
+  winner,
+  players,
+  turnLog,
+  startedAt,
+  currentTurn,
+  onSave,
+  onRematch,
+}: WinnerOverlayProps) {
+  const totalDurationMs = Date.now() - startedAt
+  const winnerLabel = winner.displayName || winner.commanderName
+
+  return (
+    <Dialog open>
+      {/* Hide the default X close button — user must choose Save or Rematch */}
+      <DialogContent className="max-w-sm [&>button:last-child]:hidden">
+        <DialogHeader className="items-center text-center">
+          <div className="w-16 h-16 rounded-full bg-yellow-500/10 border-2 border-yellow-500 flex items-center justify-center mb-2">
+            <Trophy className="h-8 w-8 text-yellow-500" />
+          </div>
+          <p className="text-xs uppercase tracking-widest text-muted-foreground font-medium">Winner</p>
+          <DialogTitle className="text-2xl leading-tight">{winnerLabel}</DialogTitle>
+          {winner.commanderName && winner.displayName && (
+            <p className="text-sm text-muted-foreground">{winner.commanderName}</p>
+          )}
+        </DialogHeader>
+
+        <Separator />
+
+        {/* Stats row */}
+        <div className="grid grid-cols-2 gap-2 text-center">
+          <div className="rounded-lg border bg-muted/50 px-3 py-2">
+            <p className="text-xl font-black">{currentTurn}</p>
+            <p className="text-xs text-muted-foreground">turns</p>
+          </div>
+          <div className="rounded-lg border bg-muted/50 px-3 py-2">
+            <p className="text-xl font-black">{formatDuration(totalDurationMs)}</p>
+            <p className="text-xs text-muted-foreground">duration</p>
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Final life totals */}
+        <div className="space-y-1.5">
+          <p className="text-xs uppercase tracking-widest text-muted-foreground font-medium">Final life totals</p>
+          {players.map((p) => (
+            <div key={p.id} className="flex items-center justify-between rounded-md border px-3 py-2 bg-muted/30">
+              <span className={`text-sm font-medium truncate mr-2 ${p.id === winner.id ? "text-yellow-600 dark:text-yellow-400" : ""}`}>
+                {p.displayName || p.commanderName}
+              </span>
+              <span className={`text-sm font-bold tabular-nums shrink-0 ${p.isEliminated ? "text-muted-foreground" : ""}`}>
+                {p.isEliminated ? `Out T${p.eliminatedOnTurn}` : p.lifeTotal}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-1">
+          <Button variant="outline" className="flex-1" onClick={onRematch}>
+            Rematch
+          </Button>
+          <Button className="flex-1" onClick={onSave}>
+            Save Game
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/live/WinnerOverlay.tsx
+++ b/src/components/live/WinnerOverlay.tsx
@@ -7,12 +7,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import type { LivePlayer, TurnLogEntry } from "@/types/live"
+import type { LivePlayer } from "@/types/live"
 
 interface WinnerOverlayProps {
   winner: LivePlayer
   players: LivePlayer[]
-  turnLog: TurnLogEntry[]
   startedAt: number
   currentTurn: number
   onSave: () => void
@@ -32,7 +31,6 @@ function formatDuration(ms: number): string {
 export function WinnerOverlay({
   winner,
   players,
-  turnLog,
   startedAt,
   currentTurn,
   onSave,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[70] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[70] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/hooks/useLiveGame.ts
+++ b/src/hooks/useLiveGame.ts
@@ -1,0 +1,319 @@
+import { useReducer, useRef, useCallback } from "react"
+import type { Player } from "@/types"
+import type {
+  LiveGameState,
+  LivePlayer,
+  TurnLogEntry,
+  DragState,
+  DamageSheetState,
+} from "@/types/live"
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function checkElimination(p: LivePlayer): LivePlayer["eliminationCause"] | null {
+  if (p.lifeTotal <= 0) return "life"
+  if (p.poisonCounters >= 10) return "poison"
+  for (const dmg of Object.values(p.commanderDamageReceived)) {
+    if (dmg >= 21) return "commanderDamage"
+  }
+  return null
+}
+
+function applyEliminations(players: LivePlayer[], currentTurn: number): LivePlayer[] {
+  return players.map((p) => {
+    if (p.isEliminated) return p
+    const cause = checkElimination(p)
+    if (cause) return { ...p, isEliminated: true, eliminatedOnTurn: currentTurn, eliminationCause: cause }
+    return p
+  })
+}
+
+function detectWinner(players: LivePlayer[]): string | null {
+  const alive = players.filter((p) => !p.isEliminated)
+  return alive.length === 1 ? alive[0].id : null
+}
+
+function nextAliveIndex(players: LivePlayer[], from: number): number {
+  const n = players.length
+  let idx = (from + 1) % n
+  for (let i = 0; i < n; i++) {
+    if (!players[idx].isEliminated) return idx
+    idx = (idx + 1) % n
+  }
+  return from
+}
+
+function commitAllDeltas(players: LivePlayer[]): LivePlayer[] {
+  return players.map((p) =>
+    p.pendingDelta !== 0 ? { ...p, lifeTotal: Math.max(0, p.lifeTotal + p.pendingDelta), pendingDelta: 0 } : p
+  )
+}
+
+// ─── Actions ────────────────────────────────────────────────────────────────
+
+type Action =
+  | { type: "ADJUST_DELTA"; playerId: string; delta: number }
+  | { type: "COMMIT_DELTA"; playerId: string }
+  | { type: "APPLY_DAMAGE"; targetId: string; sourceId: string; amount: number; damageType: "regular" | "commander"; lifelink: boolean }
+  | { type: "ADJUST_POISON"; playerId: string; delta: number }
+  | { type: "END_TURN" }
+  | { type: "OPEN_DAMAGE_SHEET"; sourceId: string; targetId: string }
+  | { type: "CLOSE_DAMAGE_SHEET" }
+  | { type: "UPDATE_DAMAGE_SHEET"; amount?: number; damageType?: "regular" | "commander"; lifelink?: boolean }
+  | { type: "START_DRAG"; playerId: string; x: number; y: number }
+  | { type: "UPDATE_DRAG"; x: number; y: number; hoveredTargetId: string | null }
+  | { type: "CANCEL_DRAG" }
+
+// ─── Reducer ────────────────────────────────────────────────────────────────
+
+function reducer(state: LiveGameState, action: Action): LiveGameState {
+  switch (action.type) {
+    case "ADJUST_DELTA": {
+      const players = state.players.map((p) =>
+        p.id === action.playerId ? { ...p, pendingDelta: p.pendingDelta + action.delta } : p
+      )
+      return { ...state, players }
+    }
+
+    case "COMMIT_DELTA": {
+      let players = state.players.map((p) => {
+        if (p.id !== action.playerId || p.pendingDelta === 0) return p
+        return { ...p, lifeTotal: Math.max(0, p.lifeTotal + p.pendingDelta), pendingDelta: 0 }
+      })
+      players = applyEliminations(players, state.currentTurn)
+      const winnerId = detectWinner(players) ?? state.winnerId
+      return { ...state, players, winnerId }
+    }
+
+    case "APPLY_DAMAGE": {
+      let players = state.players.map((p) => {
+        if (p.id === action.targetId) {
+          const newLife = Math.max(0, p.lifeTotal - action.amount)
+          const cmdDmg =
+            action.damageType === "commander"
+              ? { ...p.commanderDamageReceived, [action.sourceId]: (p.commanderDamageReceived[action.sourceId] ?? 0) + action.amount }
+              : p.commanderDamageReceived
+          return { ...p, lifeTotal: newLife, commanderDamageReceived: cmdDmg, pendingDelta: 0 }
+        }
+        if (p.id === action.sourceId && action.lifelink) {
+          return { ...p, lifeTotal: p.lifeTotal + action.amount }
+        }
+        return p
+      })
+      players = applyEliminations(players, state.currentTurn)
+      const winnerId = detectWinner(players) ?? state.winnerId
+      return { ...state, players, winnerId, drag: null, damageSheet: null }
+    }
+
+    case "ADJUST_POISON": {
+      let players = state.players.map((p) => {
+        if (p.id !== action.playerId) return p
+        return { ...p, poisonCounters: Math.max(0, p.poisonCounters + action.delta) }
+      })
+      players = applyEliminations(players, state.currentTurn)
+      const winnerId = detectWinner(players) ?? state.winnerId
+      return { ...state, players, winnerId }
+    }
+
+    case "END_TURN": {
+      let players = commitAllDeltas(state.players)
+      players = applyEliminations(players, state.currentTurn)
+
+      const durationMs = Date.now() - state.turnStartedAt
+      const activePlayer = state.players[state.activeSeatIndex]
+      const entry: TurnLogEntry = {
+        round: state.currentTurn,
+        seatPosition: activePlayer.seatPosition,
+        playerId: activePlayer.id,
+        durationMs,
+      }
+
+      const nextIdx = nextAliveIndex(players, state.activeSeatIndex)
+      const wrapped = nextIdx <= state.activeSeatIndex
+      const newTurn = wrapped ? state.currentTurn + 1 : state.currentTurn
+      const winnerId = detectWinner(players) ?? state.winnerId
+
+      return {
+        ...state,
+        players,
+        activeSeatIndex: nextIdx,
+        currentTurn: newTurn,
+        turnStartedAt: Date.now(),
+        turnLog: [...state.turnLog, entry],
+        winnerId,
+      }
+    }
+
+    case "OPEN_DAMAGE_SHEET": {
+      const sheet: DamageSheetState = {
+        sourcePlayerId: action.sourceId,
+        targetPlayerId: action.targetId,
+        amount: 1,
+        damageType: "regular",
+        lifelink: false,
+      }
+      return { ...state, drag: null, damageSheet: sheet }
+    }
+
+    case "CLOSE_DAMAGE_SHEET":
+      return { ...state, damageSheet: null }
+
+    case "UPDATE_DAMAGE_SHEET": {
+      if (!state.damageSheet) return state
+      return {
+        ...state,
+        damageSheet: {
+          ...state.damageSheet,
+          amount: action.amount ?? state.damageSheet.amount,
+          damageType: action.damageType ?? state.damageSheet.damageType,
+          lifelink: action.lifelink ?? state.damageSheet.lifelink,
+        },
+      }
+    }
+
+    case "START_DRAG": {
+      const drag: DragState = {
+        sourcePlayerId: action.playerId,
+        currentX: action.x,
+        currentY: action.y,
+        hoveredTargetId: null,
+      }
+      return { ...state, drag }
+    }
+
+    case "UPDATE_DRAG": {
+      if (!state.drag) return state
+      return {
+        ...state,
+        drag: {
+          ...state.drag,
+          currentX: action.x,
+          currentY: action.y,
+          hoveredTargetId: action.hoveredTargetId,
+        },
+      }
+    }
+
+    case "CANCEL_DRAG":
+      return { ...state, drag: null }
+
+    default:
+      return state
+  }
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────────
+
+export function initLiveGameState(rawPlayers: Partial<Player>[]): LiveGameState {
+  const sorted = [...rawPlayers].sort((a, b) => (a.seatPosition ?? 99) - (b.seatPosition ?? 99))
+  const players: LivePlayer[] = sorted.map((p, i) => ({
+    id: p.id ?? `player-${i}`,
+    seatPosition: p.seatPosition ?? ((i + 1) as LivePlayer["seatPosition"]),
+    displayName: p.displayName,
+    commanderName: p.commanderName ?? "Unknown",
+    commanderImageUri: p.commanderImageUri,
+    partnerName: p.partnerName,
+    partnerImageUri: p.partnerImageUri,
+    isMe: p.isMe ?? false,
+    lifeTotal: 40,
+    commanderDamageReceived: {},
+    poisonCounters: 0,
+    isEliminated: false,
+    pendingDelta: 0,
+  }))
+
+  return {
+    players,
+    startedAt: Date.now(),
+    currentTurn: 1,
+    activeSeatIndex: 0,
+    turnStartedAt: Date.now(),
+    turnLog: [],
+    drag: null,
+    damageSheet: null,
+    winnerId: null,
+  }
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+export function useLiveGame(rawPlayers: Partial<Player>[]) {
+  const [state, dispatch] = useReducer(reducer, rawPlayers, initLiveGameState)
+
+  // Per-player commit timers (1.5 s debounce)
+  const commitTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
+
+  const adjustDelta = useCallback((playerId: string, delta: number) => {
+    if (commitTimers.current[playerId]) clearTimeout(commitTimers.current[playerId])
+    dispatch({ type: "ADJUST_DELTA", playerId, delta })
+    commitTimers.current[playerId] = setTimeout(() => {
+      dispatch({ type: "COMMIT_DELTA", playerId })
+      delete commitTimers.current[playerId]
+    }, 1500)
+  }, [])
+
+  const commitDelta = useCallback((playerId: string) => {
+    if (commitTimers.current[playerId]) {
+      clearTimeout(commitTimers.current[playerId])
+      delete commitTimers.current[playerId]
+    }
+    dispatch({ type: "COMMIT_DELTA", playerId })
+  }, [])
+
+  const applyDamage = useCallback(
+    (targetId: string, sourceId: string, amount: number, damageType: "regular" | "commander", lifelink: boolean) => {
+      dispatch({ type: "APPLY_DAMAGE", targetId, sourceId, amount, damageType, lifelink })
+    },
+    []
+  )
+
+  const adjustPoison = useCallback((playerId: string, delta: number) => {
+    dispatch({ type: "ADJUST_POISON", playerId, delta })
+  }, [])
+
+  const endTurn = useCallback(() => {
+    // Cancel all pending timers; reducer commits deltas inline
+    Object.values(commitTimers.current).forEach(clearTimeout)
+    commitTimers.current = {}
+    dispatch({ type: "END_TURN" })
+  }, [])
+
+  const openDamageSheet = useCallback((sourceId: string, targetId: string) => {
+    dispatch({ type: "OPEN_DAMAGE_SHEET", sourceId, targetId })
+  }, [])
+
+  const closeDamageSheet = useCallback(() => {
+    dispatch({ type: "CLOSE_DAMAGE_SHEET" })
+  }, [])
+
+  const updateDamageSheet = useCallback((updates: { amount?: number; damageType?: "regular" | "commander"; lifelink?: boolean }) => {
+    dispatch({ type: "UPDATE_DAMAGE_SHEET", ...updates })
+  }, [])
+
+  const startDrag = useCallback((playerId: string, x: number, y: number) => {
+    dispatch({ type: "START_DRAG", playerId, x, y })
+  }, [])
+
+  const updateDrag = useCallback((x: number, y: number, hoveredTargetId: string | null) => {
+    dispatch({ type: "UPDATE_DRAG", x, y, hoveredTargetId })
+  }, [])
+
+  const cancelDrag = useCallback(() => {
+    dispatch({ type: "CANCEL_DRAG" })
+  }, [])
+
+  return {
+    state,
+    adjustDelta,
+    commitDelta,
+    applyDamage,
+    adjustPoison,
+    endTurn,
+    openDamageSheet,
+    closeDamageSheet,
+    updateDamageSheet,
+    startDrag,
+    updateDrag,
+    cancelDrag,
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -97,3 +97,15 @@
     margin: 0;
   }
 }
+
+@keyframes avatar-pop {
+  0%   { transform: scale(1); }
+  25%  { transform: scale(1.35); }
+  50%  { transform: scale(0.85); }
+  75%  { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+.live-avatar-bounce {
+  animation: avatar-pop 0.6s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}

--- a/src/pages/LogGamePage.tsx
+++ b/src/pages/LogGamePage.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useEffect } from "react"
-import { AlertCircle, ExternalLink, ChevronsUpDown } from "lucide-react"
+import { useState, useMemo, useEffect, useRef } from "react"
+import { AlertCircle, ExternalLink, ChevronsUpDown, Swords } from "lucide-react"
 import { fetchCardByName, resolveArtCrop } from "@/lib/scryfall"
 import type { MtgColor } from "@/types"
 import { Button } from "@/components/ui/button"
@@ -89,14 +89,22 @@ function getMirroredSeatOrder(totalPlayers: number): number[] {
 
 const EMPTY_ERRORS: FormErrors = { playerCount: false, players: [], noWinner: false, winTurn: false, koTiming: false }
 
+interface LivePrefillResult {
+  players: Partial<Player>[]
+  winTurn: number
+  winnerId?: string
+}
+
 interface LogGamePageProps {
   onSave: (game: Game) => void
   onCancel: () => void
   onDirtyChange?: (dirty: boolean) => void
   prefillCommander?: string
+  prefillLiveResult?: LivePrefillResult
+  onTrackLive?: (players: Partial<Player>[]) => void
 }
 
-export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander }: LogGamePageProps) {
+export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander, prefillLiveResult, onTrackLive }: LogGamePageProps) {
   const { games } = useGames()
   const [isMobile, setIsMobile] = useState(false)
 
@@ -146,6 +154,7 @@ export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander 
   const [podsOpen, setPodsOpen] = useState(false)
   const [winnerId, setWinnerId] = useState<string | null>(null)
   const [winTurn, setWinTurn] = useState("")
+  const liveResultApplied = useRef(false)
   const [clearedKoTurnPlayerIds, setClearedKoTurnPlayerIds] = useState<Set<string>>(new Set())
   const [notes, setNotes] = useState("")
   const [winConditions, setWinConditions] = useState<string[]>([])
@@ -477,6 +486,17 @@ export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander 
     return () => onDirtyChange?.(false)
   }, [hasInProgressData, onDirtyChange])
 
+  // Apply live session result once when the drawer opens pre-populated
+  useEffect(() => {
+    if (!prefillLiveResult || liveResultApplied.current) return
+    liveResultApplied.current = true
+    const { players: livePlayers, winTurn: liveWinTurn, winnerId: liveWinnerId } = prefillLiveResult
+    setPlayerCount(livePlayers.length)
+    setPlayers(livePlayers as Partial<Player>[])
+    setWinTurn(String(liveWinTurn))
+    if (liveWinnerId) setWinnerId(liveWinnerId)
+  }, [prefillLiveResult])
+
   const formErrorMessage = errors.koTiming
     ? "Winning turn can't be after all opponents are knocked out"
     : "Please fill in all highlighted fields."
@@ -701,6 +721,28 @@ export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander 
             </div>
           </div>
 
+          {/* Track Game Live */}
+          {onTrackLive && (
+            <>
+              <Separator />
+              <div className="space-y-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full gap-2 border-dashed"
+                  disabled={!playerCount}
+                  onClick={() => onTrackLive(players)}
+                >
+                  <Swords className="h-4 w-4" />
+                  Track Game Live
+                </Button>
+                <p className="text-xs text-muted-foreground text-center">
+                  (Experimental! Use at your own risk)
+                </p>
+              </div>
+            </>
+          )}
+
           {/* Key Wincon Cards */}
           <Separator />
           <div className="space-y-3">
@@ -775,13 +817,15 @@ export function LogGamePage({ onSave, onCancel, onDirtyChange, prefillCommander 
       )}
 
       {/* Actions */}
-      <div className="flex gap-2 pt-2">
-        <Button variant="outline" className="flex-1" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button className="flex-1" onClick={handleSubmit} disabled={players.length === 0}>
-          Save Game
-        </Button>
+      <div className="flex flex-col gap-2 pt-2">
+        <div className="flex gap-2">
+          <Button variant="outline" className="flex-1" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button className="flex-1" onClick={handleSubmit} disabled={players.length === 0}>
+            Save Game
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/TrackGamePage.tsx
+++ b/src/pages/TrackGamePage.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useRef, useCallback } from "react"
+import { X } from "lucide-react"
+import { toast } from "sonner"
+import type { Player } from "@/types"
+import { useLiveGame } from "@/hooks/useLiveGame"
+import { PlayerTile } from "@/components/live/PlayerTile"
+import { TurnHub } from "@/components/live/TurnHub"
+import { DamageSheet } from "@/components/live/DamageSheet"
+import { WinnerOverlay } from "@/components/live/WinnerOverlay"
+
+// ─── Layout ───────────────────────────────────────────────────────────────────
+// 6-column × 3-row CSS grid. Row 2 (auto height) holds the Turn Hub.
+// Rotations make each tile's content face the player seated at that position.
+
+interface TileLayout {
+  gridColumn: string
+  gridRow: string
+  rotation: number
+}
+
+const LAYOUTS: Record<number, TileLayout[]> = {
+  2: [
+    { gridColumn: "1 / 7", gridRow: "2", rotation: 0 },
+    { gridColumn: "1 / 7", gridRow: "1", rotation: 180 },
+  ],
+  3: [
+    { gridColumn: "2 / 6", gridRow: "2", rotation: 0 },
+    { gridColumn: "1 / 4", gridRow: "1", rotation: 180 },
+    { gridColumn: "4 / 7", gridRow: "1", rotation: 180 },
+  ],
+  4: [
+    { gridColumn: "1 / 4", gridRow: "2", rotation: 0 },
+    { gridColumn: "4 / 7", gridRow: "2", rotation: 0 },
+    { gridColumn: "4 / 7", gridRow: "1", rotation: 180 },
+    { gridColumn: "1 / 4", gridRow: "1", rotation: 180 },
+  ],
+  5: [
+    { gridColumn: "3 / 5", gridRow: "2", rotation: 0 },
+    { gridColumn: "5 / 7", gridRow: "2", rotation: 0 },
+    { gridColumn: "4 / 7", gridRow: "1", rotation: 180 },
+    { gridColumn: "1 / 4", gridRow: "1", rotation: 180 },
+    { gridColumn: "1 / 3", gridRow: "2", rotation: 0 },
+  ],
+}
+
+// Movement threshold before a pointerdown turns into a drag
+const DRAG_THRESHOLD_PX = 8
+
+interface TrackGamePageProps {
+  players: Partial<Player>[]
+  onExit: (result?: { winTurn: number; knockoutTurns: Record<string, number>; winnerId?: string }) => void
+  onRematch: () => void
+}
+
+export function TrackGamePage({ players: rawPlayers, onExit, onRematch }: TrackGamePageProps) {
+  const {
+    state,
+    adjustDelta,
+    applyDamage,
+    adjustPoison,
+    endTurn,
+    openDamageSheet,
+    closeDamageSheet,
+    updateDamageSheet,
+    startDrag,
+    updateDrag,
+    cancelDrag,
+  } = useLiveGame(rawPlayers)
+
+  const { players, currentTurn, activeSeatIndex, turnStartedAt, drag, damageSheet, winnerId, turnLog } = state
+
+  // ── Wake lock ──────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    let lock: WakeLockSentinel | null = null
+    if ("wakeLock" in navigator) {
+      navigator.wakeLock.request("screen").then((l) => { lock = l }).catch(() => {})
+    }
+    return () => { lock?.release().catch(() => {}) }
+  }, [])
+
+  // ── Drag system ────────────────────────────────────────────────────────────
+  // We use imperative window-level event listeners so pointer events are never
+  // lost to pointer capture or conditional-render timing.
+
+  // All mutable drag bookkeeping lives in a single ref — no stale-closure risk.
+  const dragSession = useRef<{
+    pointerId: number | null
+    playerId: string | null
+    startX: number
+    startY: number
+    live: boolean                    // true once movement threshold crossed
+    cleanupListeners: (() => void) | null
+  }>({ pointerId: null, playerId: null, startX: 0, startY: 0, live: false, cleanupListeners: null })
+
+  // Stable refs to the latest action callbacks
+  const startDragRef  = useRef(startDrag)
+  const updateDragRef = useRef(updateDrag)
+  const cancelDragRef = useRef(cancelDrag)
+  const openSheetRef  = useRef(openDamageSheet)
+  useEffect(() => { startDragRef.current  = startDrag  }, [startDrag])
+  useEffect(() => { updateDragRef.current = updateDrag  }, [updateDrag])
+  useEffect(() => { cancelDragRef.current = cancelDrag  }, [cancelDrag])
+  useEffect(() => { openSheetRef.current  = openDamageSheet }, [openDamageSheet])
+
+  // Find the closest tile under the pointer by data-drop-target attribute.
+  // elementsFromPoint returns all elements at (x,y) front-to-back, so we scan
+  // through to find the first one tagged as a drop target.
+  const findDropTarget = useCallback((x: number, y: number): string | null => {
+    const els = document.elementsFromPoint(x, y)
+    for (const el of els) {
+      const id = (el as HTMLElement).dataset.dropTarget
+      if (id) return id
+    }
+    return null
+  }, [])
+
+  const handleAvatarPointerDown = useCallback(
+    (e: React.PointerEvent, playerId: string) => {
+      const player = players.find((p) => p.id === playerId)
+      if (player?.isEliminated || drag) return
+
+      // Prevent text selection / default browser drag during the gesture
+      e.preventDefault()
+
+      const session = dragSession.current
+      // Clean up any previous session that didn't finish properly
+      session.cleanupListeners?.()
+
+      session.pointerId = e.pointerId
+      session.playerId  = playerId
+      session.startX    = e.clientX
+      session.startY    = e.clientY
+      session.live      = false
+
+      function onMove(ev: PointerEvent) {
+        if (ev.pointerId !== dragSession.current.pointerId) return
+        const ds = dragSession.current
+
+        if (!ds.live) {
+          const dist = Math.hypot(ev.clientX - ds.startX, ev.clientY - ds.startY)
+          if (dist < DRAG_THRESHOLD_PX) return
+          // Crossed threshold — activate drag
+          ds.live = true
+          startDragRef.current(ds.playerId!, ev.clientX, ev.clientY)
+        }
+
+        const hovered = findDropTarget(ev.clientX, ev.clientY)
+        // Don't report the source tile as a hover target
+        const target = hovered === ds.playerId ? null : hovered
+        updateDragRef.current(ev.clientX, ev.clientY, target)
+      }
+
+      function onUp(ev: PointerEvent) {
+        if (ev.pointerId !== dragSession.current.pointerId) return
+        cleanup()
+
+        const ds = dragSession.current
+        const wasLive  = ds.live
+        const sourceId = ds.playerId!
+
+        // Reset session
+        ds.pointerId = null
+        ds.playerId  = null
+        ds.live      = false
+
+        if (!wasLive) return
+
+        const targetId = findDropTarget(ev.clientX, ev.clientY)
+        if (targetId && targetId !== sourceId) {
+          openSheetRef.current(sourceId, targetId)
+        } else {
+          cancelDragRef.current()
+        }
+      }
+
+      function onCancel() {
+        cleanup()
+        dragSession.current.pointerId = null
+        dragSession.current.playerId  = null
+        dragSession.current.live      = false
+        cancelDragRef.current()
+      }
+
+      function cleanup() {
+        window.removeEventListener("pointermove",   onMove)
+        window.removeEventListener("pointerup",     onUp)
+        window.removeEventListener("pointercancel", onCancel)
+        dragSession.current.cleanupListeners = null
+      }
+
+      session.cleanupListeners = cleanup
+      window.addEventListener("pointermove",   onMove,   { passive: true })
+      window.addEventListener("pointerup",     onUp)
+      window.addEventListener("pointercancel", onCancel)
+    },
+    [players, drag, findDropTarget]
+  )
+
+  // Cleanup listeners if the component unmounts mid-drag
+  useEffect(() => {
+    return () => { dragSession.current.cleanupListeners?.() }
+  }, [])
+
+  // ── Elimination toasts ────────────────────────────────────────────────────
+
+  const prevEliminatedIds = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    for (const p of players) {
+      if (p.isEliminated && !prevEliminatedIds.current.has(p.id)) {
+        prevEliminatedIds.current.add(p.id)
+        const cause =
+          p.eliminationCause === "commanderDamage" ? "commander damage"
+          : p.eliminationCause === "poison" ? "poison counters"
+          : "life total"
+        toast.error(
+          `${p.displayName || p.commanderName} eliminated by ${cause} (T${p.eliminatedOnTurn ?? currentTurn})`,
+          { duration: 4000 }
+        )
+      }
+    }
+  }, [players, currentTurn])
+
+  // ── Exit / save ───────────────────────────────────────────────────────────
+
+  function handleSaveExit() {
+    const knockoutTurns: Record<string, number> = {}
+    for (const p of players) {
+      if (p.eliminatedOnTurn !== undefined) knockoutTurns[p.id] = p.eliminatedOnTurn
+    }
+    onExit({ winTurn: currentTurn, knockoutTurns, winnerId: winnerId ?? undefined })
+  }
+
+  function handleDiscard() {
+    if (!confirm("Discard this game session?")) return
+    onExit()
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const playerCount = Math.min(players.length, 5) as 2 | 3 | 4 | 5
+  const layouts = LAYOUTS[playerCount] ?? LAYOUTS[4]
+  const winner = winnerId ? players.find((p) => p.id === winnerId) : null
+
+  return (
+    <div className="fixed inset-0 z-[60] bg-gray-950 overflow-hidden touch-none select-none">
+      {/* Vignette */}
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_40%,rgba(0,0,0,0.55)_100%)] pointer-events-none" />
+
+      {/* Exit button */}
+      {!winnerId && (
+        <button
+          onClick={handleDiscard}
+          className="absolute top-3 right-3 z-[65] flex items-center gap-1 px-2.5 py-1.5 rounded-xl bg-white/10 border border-white/15 text-gray-400 text-xs hover:text-white transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+          End game
+        </button>
+      )}
+
+      {/* Board — two equal rows, tiles fill all screen space */}
+      <div
+        className="w-full h-full grid gap-1.5 p-1.5"
+        style={{
+          gridTemplateColumns: "repeat(6, 1fr)",
+          gridTemplateRows: "1fr 1fr",
+        }}
+      >
+        {players.map((player, idx) => {
+          const layout = layouts[idx]
+          if (!layout) return null
+          return (
+            <div
+              key={player.id}
+              // data-drop-target is always present so elementsFromPoint finds it
+              data-drop-target={player.id}
+              style={{ gridColumn: layout.gridColumn, gridRow: layout.gridRow }}
+              className="min-w-0 min-h-0"
+            >
+              <PlayerTile
+                player={player}
+                playerIndex={idx}
+                rotation={layout.rotation}
+                isActive={idx === activeSeatIndex && !winnerId}
+                isDragActive={!!drag}
+                isDragSource={drag?.sourcePlayerId === player.id}
+                isDropTarget={drag?.hoveredTargetId === player.id}
+                allPlayers={players}
+                onAdjustDelta={(delta) => adjustDelta(player.id, delta)}
+                onAvatarPointerDown={(e) => handleAvatarPointerDown(e, player.id)}
+                onAdjustPoison={(delta) => adjustPoison(player.id, delta)}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Turn Hub — floating over the tile intersection */}
+      <div className="absolute inset-0 flex items-center justify-center z-[62] pointer-events-none">
+        <div className="pointer-events-auto">
+          <TurnHub
+            currentTurn={currentTurn}
+            turnStartedAt={turnStartedAt}
+            activeSeatIndex={activeSeatIndex}
+            players={players}
+            isDragging={!!drag}
+            onEndTurn={endTurn}
+          />
+        </div>
+      </div>
+
+      {/* Drag ghost — follows the pointer */}
+      {drag && (
+        <div
+          className="fixed pointer-events-none z-[64] bg-gray-900/90 border border-white/20 text-white text-xs font-semibold rounded-full px-3 py-1.5 shadow-xl"
+          style={{
+            left: drag.currentX + 14,
+            top:  drag.currentY - 20,
+          }}
+        >
+          {players.find((p) => p.id === drag.sourcePlayerId)?.commanderName ?? "?"}
+          {drag.hoveredTargetId && (
+            <span className="text-red-400 ml-1.5">
+              → {players.find((p) => p.id === drag.hoveredTargetId)?.displayName
+                ?? players.find((p) => p.id === drag.hoveredTargetId)?.commanderName
+                ?? "?"}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Damage sheet */}
+      {damageSheet && (
+        <DamageSheet
+          sheet={damageSheet}
+          players={players}
+          onApply={() =>
+            applyDamage(
+              damageSheet.targetPlayerId,
+              damageSheet.sourcePlayerId,
+              damageSheet.amount,
+              damageSheet.damageType,
+              damageSheet.lifelink
+            )
+          }
+          onCancel={closeDamageSheet}
+          onUpdateAmount={(amount) => updateDamageSheet({ amount })}
+          onUpdateType={(damageType) => updateDamageSheet({ damageType })}
+          onUpdateLifelink={(lifelink) => updateDamageSheet({ lifelink })}
+        />
+      )}
+
+      {/* Winner overlay */}
+      {winner && (
+        <div className="animate-in fade-in duration-500">
+          <WinnerOverlay
+            winner={winner}
+            players={players}
+            turnLog={turnLog}
+            startedAt={state.startedAt}
+            currentTurn={currentTurn}
+            onSave={handleSaveExit}
+            onRematch={onRematch}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/TrackGamePage.tsx
+++ b/src/pages/TrackGamePage.tsx
@@ -67,7 +67,7 @@ export function TrackGamePage({ players: rawPlayers, onExit, onRematch }: TrackG
     cancelDrag,
   } = useLiveGame(rawPlayers)
 
-  const { players, currentTurn, activeSeatIndex, turnStartedAt, drag, damageSheet, winnerId, turnLog } = state
+  const { players, currentTurn, activeSeatIndex, turnStartedAt, drag, damageSheet, winnerId } = state
 
   // ── Wake lock ──────────────────────────────────────────────────────────────
 

--- a/src/pages/TrackGamePage.tsx
+++ b/src/pages/TrackGamePage.tsx
@@ -356,7 +356,6 @@ export function TrackGamePage({ players: rawPlayers, onExit, onRematch }: TrackG
           <WinnerOverlay
             winner={winner}
             players={players}
-            turnLog={turnLog}
             startedAt={state.startedAt}
             currentTurn={currentTurn}
             onSave={handleSaveExit}

--- a/src/types/live.ts
+++ b/src/types/live.ts
@@ -1,0 +1,53 @@
+import type { SeatPosition } from "./index"
+
+export interface LivePlayer {
+  id: string
+  seatPosition: SeatPosition
+  displayName?: string
+  commanderName: string
+  commanderImageUri?: string
+  partnerName?: string
+  partnerImageUri?: string
+  isMe: boolean
+  lifeTotal: number
+  commanderDamageReceived: Record<string, number>
+  poisonCounters: number
+  isEliminated: boolean
+  eliminatedOnTurn?: number
+  eliminationCause?: "life" | "commanderDamage" | "poison"
+  pendingDelta: number
+}
+
+export interface TurnLogEntry {
+  round: number
+  seatPosition: SeatPosition
+  playerId: string
+  durationMs: number
+}
+
+export interface DragState {
+  sourcePlayerId: string
+  currentX: number
+  currentY: number
+  hoveredTargetId: string | null
+}
+
+export interface DamageSheetState {
+  sourcePlayerId: string
+  targetPlayerId: string
+  amount: number
+  damageType: "regular" | "commander"
+  lifelink: boolean
+}
+
+export interface LiveGameState {
+  players: LivePlayer[]
+  startedAt: number
+  currentTurn: number
+  activeSeatIndex: number
+  turnStartedAt: number
+  turnLog: TurnLogEntry[]
+  drag: DragState | null
+  damageSheet: DamageSheetState | null
+  winnerId: string | null
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,10 +63,18 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "avatar-pop": {
+          "0%":   { transform: "scale(1)" },
+          "25%":  { transform: "scale(1.32)" },
+          "50%":  { transform: "scale(0.88)" },
+          "75%":  { transform: "scale(1.12)" },
+          "100%": { transform: "scale(1)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "avatar-pop": "avatar-pop 0.55s cubic-bezier(0.36, 0.07, 0.19, 0.97) forwards",
       },
     },
   },


### PR DESCRIPTION
Fullscreen Commander life tracking with drag-to-deal damage, turn timer, per-source commander damage, lifelink, poison counters, and a winner overlay.

- TrackGamePage: fixed overlay with 2-row grid, TurnHub floating at center
- PlayerTile: full-art commander background (rotated per seat), large typography, per-source commander damage badges, avatar bounce on turn start
- DamageSheet: amount picker with long-press ±5, commander damage toggle with existing-damage context, lifelink checkbox
- WinnerOverlay: stats, final life totals, save/rematch actions
- useLiveGame: useReducer state with 1.5s debounce commits, commander damage per source, lifelink life gain, poison, wake lock
- Dialog z-index raised to z-[70] to clear the z-[60] board overlay
- Track Game Live button moved above wincon in LogGamePage with experimental disclaimer; live session results prefill the log form