### PR TITLE
Prototype: reimagine History page as a personal timeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,7 +276,18 @@ function App() {
                 />
               }
             />
-            <Route path="/prototypes/history" element={<PrototypesPage games={games} />} />
+            <Route
+              path="/prototypes/history"
+              element={
+                <PrototypesPage
+                  games={games}
+                  onEditGame={openEditGameFlow}
+                  onDeleteGame={(id) => {
+                    void deleteGame(id)
+                  }}
+                />
+              }
+            />
             {/* Map page removed */}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { StatsPage } from "@/pages/StatsPage"
 import { LogGamePage } from "@/pages/LogGamePage"
 import { EditGamePage } from "@/pages/EditGamePage"
 import { HistoryPage } from "@/pages/HistoryPage"
+import { PrototypesPage } from "@/pages/PrototypesPage"
 import { SettingsPage } from "@/pages/SettingsPage"
 import { LoggedOutHomePage } from "@/pages/LoggedOutHomePage"
 import { useGames } from "@/hooks/useGames"
@@ -275,6 +276,7 @@ function App() {
                 />
               }
             />
+            <Route path="/prototypes/history" element={<PrototypesPage games={games} />} />
             {/* Map page removed */}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/prototypes/historyTimeline/CommanderAvatar.tsx
+++ b/src/components/prototypes/historyTimeline/CommanderAvatar.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react"
+import { fetchCardByName, resolveArtCrop } from "@/lib/scryfall"
+
+const artCache = new Map<string, string | null>()
+
+interface CommanderAvatarProps {
+  name?: string
+  imageUri?: string
+  size?: number
+}
+
+/**
+ * Small circular avatar showing a commander's Scryfall art crop. Resolves
+ * through the scryfall lib layer (same approach as GameHistoryRow) and caches
+ * by name so repeated rows don't refetch. Falls back to the first letter.
+ */
+export function CommanderAvatar({ name, imageUri, size = 36 }: CommanderAvatarProps) {
+  const [src, setSrc] = useState<string | undefined>(
+    imageUri && imageUri.includes("art_crop") ? imageUri : undefined
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    if (!name) return
+
+    if (imageUri && imageUri.includes("art_crop")) {
+      setSrc(imageUri)
+      return
+    }
+    const cached = artCache.get(name)
+    if (cached !== undefined) {
+      setSrc(cached ?? undefined)
+      return
+    }
+
+    fetchCardByName(name)
+      .then((card) => {
+        const uri = resolveArtCrop(card) ?? imageUri
+        artCache.set(name, uri ?? null)
+        if (!cancelled) setSrc(uri ?? undefined)
+      })
+      .catch(() => {
+        artCache.set(name, null)
+        if (!cancelled) setSrc(imageUri)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [name, imageUri])
+
+  const initial = name?.trim()?.[0]?.toUpperCase() ?? "?"
+
+  return (
+    <span
+      className="inline-grid shrink-0 place-items-center overflow-hidden rounded-full border border-border bg-muted"
+      style={{ width: size, height: size }}
+    >
+      {src ? (
+        <img src={src} alt={name ?? ""} className="h-full w-full object-cover object-center" />
+      ) : (
+        <span className="text-xs font-semibold text-muted-foreground">{initial}</span>
+      )}
+    </span>
+  )
+}

--- a/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
+++ b/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
@@ -12,11 +12,18 @@ const STYLES: Record<MilestoneKind, { icon?: IconType; className: string }> = {
   win: { icon: Crown, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
   "fast-win": { icon: Zap, className: "bg-sky-500/15 text-sky-600 dark:text-sky-400" },
+  "slow-burn": { className: "bg-lime-500/15 text-lime-600 dark:text-lime-400" },
   wincon: { icon: Swords, className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" },
   "tough-seat": { className: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400" },
   underdog: { className: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400" },
+  nemesis: { className: "bg-red-500/15 text-red-600 dark:text-red-400" },
+  "new-rival": { className: "bg-teal-500/15 text-teal-600 dark:text-teal-400" },
+  comeback: { className: "bg-green-500/15 text-green-600 dark:text-green-400" },
+  "color-pioneer": { className: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400" },
+  "bracket-buster": { className: "bg-purple-500/15 text-purple-600 dark:text-purple-400" },
+  "flawless-month": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   knockout: { icon: Skull, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
-  "loss-streak": { icon: undefined, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
+  "loss-streak": { className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
 }
 
 /** Compact pill — used where several milestones sit inline. */

--- a/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
+++ b/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
@@ -1,0 +1,25 @@
+import { Award, Flag, Flame, Sparkles, Trophy, Zap } from "lucide-react"
+import type { Milestone, MilestoneKind } from "./timeline"
+
+const STYLES: Record<MilestoneKind, { icon: typeof Trophy; className: string }> = {
+  "first-game": { icon: Flag, className: "bg-muted text-foreground" },
+  "first-win": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
+  "milestone-game": { icon: Award, className: "bg-primary/15 text-primary" },
+  streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
+  debut: { icon: Sparkles, className: "bg-violet-500/15 text-violet-600 dark:text-violet-400" },
+  "fast-win": { icon: Zap, className: "bg-sky-500/15 text-sky-600 dark:text-sky-400" },
+}
+
+export function MilestoneBadge({ milestone }: { milestone: Milestone }) {
+  const { icon: Icon, className } = STYLES[milestone.kind]
+  return (
+    <span
+      className={
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium " + className
+      }
+    >
+      <Icon className="h-3 w-3 shrink-0" />
+      {milestone.label}
+    </span>
+  )
+}

--- a/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
+++ b/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
@@ -1,41 +1,72 @@
-import { Award, Crown, Flag, Flame, Skull, Sparkles, Swords, Trophy, Zap } from "lucide-react"
+import {
+  Award,
+  Baby,
+  Crown,
+  Flag,
+  Flame,
+  Gem,
+  Handshake,
+  Hourglass,
+  Medal,
+  Rainbow,
+  RotateCcw,
+  Skull,
+  Sprout,
+  Star,
+  Sword,
+  Swords,
+  Target,
+  TrendingDown,
+  TrendingUp,
+  Trophy,
+  Turtle,
+  Zap,
+} from "lucide-react"
 import type { Milestone, MilestoneKind } from "./timeline"
 
 type IconType = typeof Trophy
 
-const STYLES: Record<MilestoneKind, { icon?: IconType; className: string }> = {
+/** Icons addressable by name for per-milestone overrides (e.g. veteran tiers). */
+const ICONS: Record<string, IconType> = { Sprout, Star, Medal, Gem }
+
+const STYLES: Record<MilestoneKind, { icon: IconType; className: string }> = {
   "first-game": { icon: Flag, className: "bg-muted text-foreground" },
   "milestone-game": { icon: Award, className: "bg-primary/15 text-primary" },
-  debut: { icon: Sparkles, className: "bg-violet-500/15 text-violet-600 dark:text-violet-400" },
-  veteran: { className: "bg-stone-500/15 text-stone-600 dark:text-stone-300" },
+  debut: { icon: Baby, className: "bg-violet-500/15 text-violet-600 dark:text-violet-400" },
+  veteran: { icon: Star, className: "bg-stone-500/15 text-stone-600 dark:text-stone-300" },
   "first-win": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   win: { icon: Crown, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
   "fast-win": { icon: Zap, className: "bg-sky-500/15 text-sky-600 dark:text-sky-400" },
-  "slow-burn": { className: "bg-lime-500/15 text-lime-600 dark:text-lime-400" },
+  "slow-burn": { icon: Hourglass, className: "bg-lime-500/15 text-lime-600 dark:text-lime-400" },
   wincon: { icon: Swords, className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" },
-  "tough-seat": { className: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400" },
-  underdog: { className: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400" },
-  nemesis: { className: "bg-red-500/15 text-red-600 dark:text-red-400" },
-  "new-rival": { className: "bg-teal-500/15 text-teal-600 dark:text-teal-400" },
-  comeback: { className: "bg-green-500/15 text-green-600 dark:text-green-400" },
-  "color-pioneer": { className: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400" },
-  "bracket-buster": { className: "bg-purple-500/15 text-purple-600 dark:text-purple-400" },
+  "tough-seat": { icon: Target, className: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400" },
+  underdog: { icon: Turtle, className: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400" },
+  nemesis: { icon: Sword, className: "bg-red-500/15 text-red-600 dark:text-red-400" },
+  "new-rival": { icon: Handshake, className: "bg-teal-500/15 text-teal-600 dark:text-teal-400" },
+  comeback: { icon: RotateCcw, className: "bg-green-500/15 text-green-600 dark:text-green-400" },
+  "color-pioneer": { icon: Rainbow, className: "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400" },
+  "bracket-buster": { icon: TrendingUp, className: "bg-purple-500/15 text-purple-600 dark:text-purple-400" },
   "flawless-month": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   knockout: { icon: Skull, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
-  "loss-streak": { className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
+  "loss-streak": { icon: TrendingDown, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
+}
+
+function iconFor(milestone: Milestone): IconType {
+  return (milestone.iconName && ICONS[milestone.iconName]) || STYLES[milestone.kind].icon
 }
 
 /** Compact pill — used where several milestones sit inline. */
 export function MilestoneBadge({ milestone }: { milestone: Milestone }) {
-  const { icon: Icon, className } = STYLES[milestone.kind]
+  const Icon = iconFor(milestone)
   return (
-    <span className={"inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-medium " + className}>
-      {milestone.emoji ? (
-        <span className="text-base leading-none">{milestone.emoji}</span>
-      ) : Icon ? (
-        <Icon className="h-4 w-4 shrink-0" />
-      ) : null}
+    <span
+      className={
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-medium " +
+        STYLES[milestone.kind].className
+      }
+    >
+      <Icon className="h-4 w-4 shrink-0" />
       {milestone.label}
     </span>
   )
@@ -43,15 +74,11 @@ export function MilestoneBadge({ milestone }: { milestone: Milestone }) {
 
 /** Full discrete highlight event — headline + supporting detail. */
 export function MilestoneEvent({ milestone }: { milestone: Milestone }) {
-  const { icon: Icon, className } = STYLES[milestone.kind]
+  const Icon = iconFor(milestone)
   return (
     <div className="flex items-center gap-3">
-      <span className={"grid h-9 w-9 shrink-0 place-items-center rounded-full " + className}>
-        {milestone.emoji ? (
-          <span className="text-xl leading-none">{milestone.emoji}</span>
-        ) : Icon ? (
-          <Icon className="h-5 w-5" />
-        ) : null}
+      <span className={"grid h-9 w-9 shrink-0 place-items-center rounded-full " + STYLES[milestone.kind].className}>
+        <Icon className="h-5 w-5" />
       </span>
       <div className="min-w-0">
         <div className="text-base font-semibold leading-tight">{milestone.label}</div>

--- a/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
+++ b/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
@@ -1,28 +1,34 @@
 import { Award, Crown, Flag, Flame, Skull, Sparkles, Swords, Trophy, Zap } from "lucide-react"
 import type { Milestone, MilestoneKind } from "./timeline"
 
-const STYLES: Record<MilestoneKind, { icon: typeof Trophy; className: string }> = {
+type IconType = typeof Trophy
+
+const STYLES: Record<MilestoneKind, { icon?: IconType; className: string }> = {
   "first-game": { icon: Flag, className: "bg-muted text-foreground" },
   "milestone-game": { icon: Award, className: "bg-primary/15 text-primary" },
   debut: { icon: Sparkles, className: "bg-violet-500/15 text-violet-600 dark:text-violet-400" },
+  veteran: { className: "bg-stone-500/15 text-stone-600 dark:text-stone-300" },
   "first-win": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   win: { icon: Crown, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
   "fast-win": { icon: Zap, className: "bg-sky-500/15 text-sky-600 dark:text-sky-400" },
   wincon: { icon: Swords, className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" },
+  "tough-seat": { className: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400" },
+  underdog: { className: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400" },
   knockout: { icon: Skull, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
+  "loss-streak": { icon: undefined, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
 }
 
 /** Compact pill — used where several milestones sit inline. */
 export function MilestoneBadge({ milestone }: { milestone: Milestone }) {
   const { icon: Icon, className } = STYLES[milestone.kind]
   return (
-    <span
-      className={
-        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-medium " + className
-      }
-    >
-      <Icon className="h-4 w-4 shrink-0" />
+    <span className={"inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-medium " + className}>
+      {milestone.emoji ? (
+        <span className="text-base leading-none">{milestone.emoji}</span>
+      ) : Icon ? (
+        <Icon className="h-4 w-4 shrink-0" />
+      ) : null}
       {milestone.label}
     </span>
   )
@@ -34,7 +40,11 @@ export function MilestoneEvent({ milestone }: { milestone: Milestone }) {
   return (
     <div className="flex items-center gap-3">
       <span className={"grid h-9 w-9 shrink-0 place-items-center rounded-full " + className}>
-        <Icon className="h-5 w-5" />
+        {milestone.emoji ? (
+          <span className="text-xl leading-none">{milestone.emoji}</span>
+        ) : Icon ? (
+          <Icon className="h-5 w-5" />
+        ) : null}
       </span>
       <div className="min-w-0">
         <div className="text-base font-semibold leading-tight">{milestone.label}</div>

--- a/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
+++ b/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
@@ -1,4 +1,4 @@
-import { Award, Crown, Flag, Flame, Sparkles, Swords, Trophy, Zap } from "lucide-react"
+import { Award, Crown, Flag, Flame, Skull, Sparkles, Swords, Trophy, Zap } from "lucide-react"
 import type { Milestone, MilestoneKind } from "./timeline"
 
 const STYLES: Record<MilestoneKind, { icon: typeof Trophy; className: string }> = {
@@ -10,6 +10,7 @@ const STYLES: Record<MilestoneKind, { icon: typeof Trophy; className: string }> 
   streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
   "fast-win": { icon: Zap, className: "bg-sky-500/15 text-sky-600 dark:text-sky-400" },
   wincon: { icon: Swords, className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" },
+  knockout: { icon: Skull, className: "bg-rose-500/15 text-rose-600 dark:text-rose-400" },
 }
 
 /** Compact pill — used where several milestones sit inline. */

--- a/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
+++ b/src/components/prototypes/historyTimeline/MilestoneBadge.tsx
@@ -1,25 +1,46 @@
-import { Award, Flag, Flame, Sparkles, Trophy, Zap } from "lucide-react"
+import { Award, Crown, Flag, Flame, Sparkles, Swords, Trophy, Zap } from "lucide-react"
 import type { Milestone, MilestoneKind } from "./timeline"
 
 const STYLES: Record<MilestoneKind, { icon: typeof Trophy; className: string }> = {
   "first-game": { icon: Flag, className: "bg-muted text-foreground" },
-  "first-win": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
   "milestone-game": { icon: Award, className: "bg-primary/15 text-primary" },
-  streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
   debut: { icon: Sparkles, className: "bg-violet-500/15 text-violet-600 dark:text-violet-400" },
+  "first-win": { icon: Trophy, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
+  win: { icon: Crown, className: "bg-amber-500/15 text-amber-600 dark:text-amber-400" },
+  streak: { icon: Flame, className: "bg-orange-500/15 text-orange-600 dark:text-orange-400" },
   "fast-win": { icon: Zap, className: "bg-sky-500/15 text-sky-600 dark:text-sky-400" },
+  wincon: { icon: Swords, className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" },
 }
 
+/** Compact pill — used where several milestones sit inline. */
 export function MilestoneBadge({ milestone }: { milestone: Milestone }) {
   const { icon: Icon, className } = STYLES[milestone.kind]
   return (
     <span
       className={
-        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium " + className
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-sm font-medium " + className
       }
     >
-      <Icon className="h-3 w-3 shrink-0" />
+      <Icon className="h-4 w-4 shrink-0" />
       {milestone.label}
     </span>
+  )
+}
+
+/** Full discrete highlight event — headline + supporting detail. */
+export function MilestoneEvent({ milestone }: { milestone: Milestone }) {
+  const { icon: Icon, className } = STYLES[milestone.kind]
+  return (
+    <div className="flex items-center gap-3">
+      <span className={"grid h-9 w-9 shrink-0 place-items-center rounded-full " + className}>
+        <Icon className="h-5 w-5" />
+      </span>
+      <div className="min-w-0">
+        <div className="text-base font-semibold leading-tight">{milestone.label}</div>
+        {milestone.detail && (
+          <div className="text-sm text-muted-foreground leading-tight">{milestone.detail}</div>
+        )}
+      </div>
+    </div>
   )
 }

--- a/src/components/prototypes/historyTimeline/VariantChapters.tsx
+++ b/src/components/prototypes/historyTimeline/VariantChapters.tsx
@@ -1,0 +1,95 @@
+import { CARD, Pips, ResultBadge, WrBar } from "@/components/modern/primitives"
+import type { Game } from "@/types"
+import { MilestoneBadge } from "./MilestoneBadge"
+import {
+  buildTimeline,
+  colorsOf,
+  dayLabel,
+  groupByMonth,
+  opponentsOf,
+  shortCommander,
+} from "./timeline"
+
+/**
+ * Variant B — "Chapters".
+ * Your career told month by month. Each month is a chapter with a narrative
+ * header (record, win rate, signature deck), then the games of that month as a
+ * compact run. Milestones surface as inline highlight strips between games.
+ */
+export function VariantChapters({ games }: { games: Game[] }) {
+  const events = buildTimeline(games)
+  const chapters = groupByMonth(events)
+
+  if (chapters.length === 0) {
+    return <p className="text-sm text-muted-foreground">No games yet.</p>
+  }
+
+  return (
+    <div className="space-y-8">
+      {chapters.map((chapter) => (
+        <section key={chapter.key}>
+          <div className={CARD + " p-4 sm:p-5"}>
+            <div className="flex items-baseline justify-between gap-3">
+              <h2 className="text-base font-semibold tracking-tight">{chapter.label}</h2>
+              <span className="font-mono text-[11px] text-muted-foreground tabular">
+                {chapter.wins}–{chapter.games - chapter.wins}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {chapter.games} {chapter.games === 1 ? "game" : "games"}
+              {chapter.topCommander ? ` · mostly ${shortCommander(chapter.topCommander)}` : ""}
+            </p>
+            <div className="mt-3 flex items-center gap-3">
+              <WrBar rate={chapter.winRate} />
+              <span className="shrink-0 font-mono text-[11px] text-muted-foreground tabular">
+                {Math.round(chapter.winRate * 100)}%
+              </span>
+            </div>
+          </div>
+
+          <ul className="mt-3 space-y-2">
+            {chapter.events.map((ev) => {
+              const colors = colorsOf(ev.me)
+              const opponents = opponentsOf(ev.game)
+              return (
+                <li key={ev.game.id}>
+                  {ev.milestones.length > 0 && (
+                    <div className="mb-2 flex flex-wrap gap-1.5 pl-1">
+                      {ev.milestones.map((m, i) => (
+                        <MilestoneBadge key={i} milestone={m} />
+                      ))}
+                    </div>
+                  )}
+                  <div className={CARD + " flex items-center gap-3 px-4 py-3"}>
+                    <ResultBadge won={ev.won} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-sm font-semibold">
+                          {shortCommander(ev.me?.commanderName)}
+                        </span>
+                        {colors.length > 0 && (
+                          <span className="hidden sm:inline-flex">
+                            <Pips colors={colors} />
+                          </span>
+                        )}
+                      </div>
+                      {opponents.length > 0 && (
+                        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                          vs {opponents.join(" · ")}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 text-right font-mono text-[11px] text-muted-foreground tabular leading-5">
+                      <div>{dayLabel(ev.date)}</div>
+                      {ev.game.winTurn ? <div>{ev.game.winTurn} turns</div> : null}
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/components/prototypes/historyTimeline/VariantChapters.tsx
+++ b/src/components/prototypes/historyTimeline/VariantChapters.tsx
@@ -12,59 +12,61 @@ import {
 
 /**
  * Variant B — "Chapters".
- * Your career told month by month. Each month is a chapter with a narrative
- * header (record, win rate, signature deck), then the games of that month as a
- * compact run. Milestones surface as inline highlight strips between games.
+ * Your career told month by month. Each month is a chapter with a record, win
+ * rate and its most-played deck, then the games as a run with milestone
+ * highlights surfaced above the game they happened in.
  */
 export function VariantChapters({ games }: { games: Game[] }) {
   const events = buildTimeline(games)
   const chapters = groupByMonth(events)
 
   if (chapters.length === 0) {
-    return <p className="text-sm text-muted-foreground">No games yet.</p>
+    return <p className="text-base text-muted-foreground">No games yet.</p>
   }
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
       {chapters.map((chapter) => (
         <section key={chapter.key}>
-          <div className={CARD + " p-4 sm:p-5"}>
+          <div className={CARD + " p-5"}>
             <div className="flex items-baseline justify-between gap-3">
-              <h2 className="text-base font-semibold tracking-tight">{chapter.label}</h2>
-              <span className="font-mono text-[11px] text-muted-foreground tabular">
+              <h2 className="text-xl font-semibold tracking-tight">{chapter.label}</h2>
+              <span className="font-mono text-base text-muted-foreground tabular">
                 {chapter.wins}–{chapter.games - chapter.wins}
               </span>
             </div>
-            <p className="mt-1 text-xs text-muted-foreground">
-              {chapter.games} {chapter.games === 1 ? "game" : "games"}
-              {chapter.topCommander ? ` · mostly ${shortCommander(chapter.topCommander)}` : ""}
+            <p className="mt-1.5 text-base text-muted-foreground">
+              {chapter.games} {chapter.games === 1 ? "game" : "games"} played
+              {chapter.topCommander
+                ? ` · most played ${shortCommander(chapter.topCommander)} (${chapter.topCommanderGames})`
+                : ""}
             </p>
-            <div className="mt-3 flex items-center gap-3">
+            <div className="mt-4 flex items-center gap-3">
               <WrBar rate={chapter.winRate} />
-              <span className="shrink-0 font-mono text-[11px] text-muted-foreground tabular">
-                {Math.round(chapter.winRate * 100)}%
+              <span className="shrink-0 font-mono text-base text-muted-foreground tabular">
+                {Math.round(chapter.winRate * 100)}% win rate
               </span>
             </div>
           </div>
 
-          <ul className="mt-3 space-y-2">
+          <ul className="mt-4 space-y-3">
             {chapter.events.map((ev) => {
               const colors = colorsOf(ev.me)
               const opponents = opponentsOf(ev.game)
               return (
                 <li key={ev.game.id}>
                   {ev.milestones.length > 0 && (
-                    <div className="mb-2 flex flex-wrap gap-1.5 pl-1">
+                    <div className="mb-2 flex flex-wrap gap-2 pl-1">
                       {ev.milestones.map((m, i) => (
                         <MilestoneBadge key={i} milestone={m} />
                       ))}
                     </div>
                   )}
-                  <div className={CARD + " flex items-center gap-3 px-4 py-3"}>
+                  <div className={CARD + " flex items-center gap-3 px-4 py-4"}>
                     <ResultBadge won={ev.won} />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <span className="truncate text-sm font-semibold">
+                        <span className="truncate text-base font-semibold">
                           {shortCommander(ev.me?.commanderName)}
                         </span>
                         {colors.length > 0 && (
@@ -74,12 +76,12 @@ export function VariantChapters({ games }: { games: Game[] }) {
                         )}
                       </div>
                       {opponents.length > 0 && (
-                        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                        <div className="mt-0.5 truncate text-sm text-muted-foreground">
                           vs {opponents.join(" · ")}
                         </div>
                       )}
                     </div>
-                    <div className="shrink-0 text-right font-mono text-[11px] text-muted-foreground tabular leading-5">
+                    <div className="shrink-0 text-right font-mono text-sm text-muted-foreground tabular leading-6">
                       <div>{dayLabel(ev.date)}</div>
                       {ev.game.winTurn ? <div>{ev.game.winTurn} turns</div> : null}
                     </div>

--- a/src/components/prototypes/historyTimeline/VariantFeed.tsx
+++ b/src/components/prototypes/historyTimeline/VariantFeed.tsx
@@ -5,7 +5,7 @@ import type { Game } from "@/types"
 import { MilestoneBadge } from "./MilestoneBadge"
 import { buildTimeline, opponentsOf, shortCommander, type TimelineEvent } from "./timeline"
 
-// ── Contribution heatmap ─────────────────────────────────────────────────────
+// ── Contribution heatmap (games played per day) ──────────────────────────────
 
 function dayKey(d: Date): string {
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
@@ -15,8 +15,18 @@ function startOfDay(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate())
 }
 
+const CELL = "h-[14px] w-[14px] rounded-[3px]"
+
+function intensityClass(count: number, max: number): string {
+  if (count <= 0) return "bg-muted/50"
+  const ratio = max <= 1 ? 1 : count / max
+  if (ratio > 0.66) return "bg-primary"
+  if (ratio > 0.33) return "bg-primary/60"
+  return "bg-primary/30"
+}
+
 function Heatmap({ events }: { events: TimelineEvent[] }) {
-  const { weeks, monthMarks, max } = useMemo(() => {
+  const { weeks, monthMarks, max, totalGames } = useMemo(() => {
     const counts = new Map<string, number>()
     let max = 0
     for (const ev of events) {
@@ -30,7 +40,6 @@ function Heatmap({ events }: { events: TimelineEvent[] }) {
     const last = dates.length ? new Date(Math.max(...dates)) : new Date()
     const earliest = dates.length ? new Date(Math.min(...dates)) : new Date()
 
-    // start at the Sunday on/before the earliest game (cap at ~20 weeks)
     const start = startOfDay(earliest)
     start.setDate(start.getDate() - start.getDay())
     const end = startOfDay(last)
@@ -58,47 +67,53 @@ function Heatmap({ events }: { events: TimelineEvent[] }) {
       weeks.push(week)
       col++
     }
-    return { weeks, monthMarks, max }
+    return { weeks, monthMarks, max, totalGames: events.length }
   }, [events])
 
-  function intensity(count: number): string {
-    if (count <= 0) return "bg-muted/50"
-    const ratio = max <= 1 ? 1 : count / max
-    if (ratio > 0.66) return "bg-primary"
-    if (ratio > 0.33) return "bg-primary/60"
-    return "bg-primary/30"
-  }
-
   return (
-    <div className="overflow-x-auto no-scrollbar">
-      <div className="inline-block min-w-full">
-        <div className="flex gap-[3px] pl-7">
-          {weeks.map((_, col) => {
-            const mark = monthMarks.find((m) => m.col === col)
-            return (
-              <div key={col} className="w-[12px] text-[9px] text-muted-foreground">
-                {mark?.label ?? ""}
-              </div>
-            )
-          })}
-        </div>
-        <div className="mt-1 flex gap-[3px]">
-          <div className="mr-1 flex flex-col justify-between py-[1px] text-[9px] text-muted-foreground">
-            <span>Mon</span>
-            <span>Wed</span>
-            <span>Fri</span>
+    <div>
+      <div className="overflow-x-auto no-scrollbar">
+        <div className="inline-block min-w-full">
+          <div className="flex gap-[3px] pl-9">
+            {weeks.map((_, col) => {
+              const mark = monthMarks.find((m) => m.col === col)
+              return (
+                <div key={col} className="w-[14px] text-[11px] text-muted-foreground">
+                  {mark?.label ?? ""}
+                </div>
+              )
+            })}
           </div>
-          {weeks.map((week, col) => (
-            <div key={col} className="flex flex-col gap-[3px]">
-              {week.map((cell) => (
-                <div
-                  key={cell.date.toISOString()}
-                  title={`${cell.date.toLocaleDateString()} — ${cell.count} game${cell.count === 1 ? "" : "s"}`}
-                  className={cn("h-[12px] w-[12px] rounded-[2px]", intensity(cell.count))}
-                />
-              ))}
+          <div className="mt-1 flex gap-[3px]">
+            <div className="mr-1 flex flex-col justify-between py-[2px] text-[11px] text-muted-foreground">
+              <span>Mon</span>
+              <span>Wed</span>
+              <span>Fri</span>
             </div>
-          ))}
+            {weeks.map((week, col) => (
+              <div key={col} className="flex flex-col gap-[3px]">
+                {week.map((cell) => (
+                  <div
+                    key={cell.date.toISOString()}
+                    title={`${cell.date.toLocaleDateString()} — ${cell.count} game${cell.count === 1 ? "" : "s"} played`}
+                    className={cn(CELL, intensityClass(cell.count, max))}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between text-sm text-muted-foreground">
+        <span>{totalGames} games played</span>
+        <div className="flex items-center gap-1.5">
+          <span>Fewer</span>
+          <span className={cn(CELL, "bg-muted/50")} />
+          <span className={cn(CELL, "bg-primary/30")} />
+          <span className={cn(CELL, "bg-primary/60")} />
+          <span className={cn(CELL, "bg-primary")} />
+          <span>More</span>
         </div>
       </div>
     </div>
@@ -125,26 +140,24 @@ function FeedLine({ event }: { event: TimelineEvent }) {
   const opponents = opponentsOf(game)
 
   return (
-    <li className="flex gap-3">
+    <li className="flex gap-3.5">
       <span
         className={cn(
-          "mt-1.5 h-2 w-2 shrink-0 rounded-full",
+          "mt-2 h-2.5 w-2.5 shrink-0 rounded-full",
           won ? "bg-primary" : "bg-muted-foreground/40"
         )}
       />
-      <div className="min-w-0 flex-1 pb-4">
-        <p className="text-sm">
+      <div className="min-w-0 flex-1 pb-5">
+        <p className="text-base leading-snug">
           <span className="font-semibold">{won ? "Won" : "Lost"}</span> with{" "}
-          <span className="font-medium">{cmdr}</span>
+          <span className="font-semibold">{cmdr}</span>
           {won && game.winTurn ? ` on turn ${game.winTurn}` : ""}
           {opponents.length > 0 ? (
             <span className="text-muted-foreground"> vs {opponents.join(" · ")}</span>
           ) : null}
         </p>
-        <div className="mt-1 flex flex-wrap items-center gap-2">
-          <span className="font-mono text-[11px] text-muted-foreground tabular">
-            {relativeTime(date)}
-          </span>
+        <div className="mt-1.5 flex flex-wrap items-center gap-2">
+          <span className="font-mono text-sm text-muted-foreground tabular">{relativeTime(date)}</span>
           {milestones.map((m, i) => (
             <MilestoneBadge key={i} milestone={m} />
           ))}
@@ -156,27 +169,28 @@ function FeedLine({ event }: { event: TimelineEvent }) {
 
 /**
  * Variant C — "Activity".
- * A social-style feed of your play, fronted by a GitHub-style contribution
- * heatmap so you can feel the rhythm of how often you get to the table.
+ * A games-played heatmap so you can feel how often you get to the table, over a
+ * social-style feed of wins, losses and milestones.
  */
 export function VariantFeed({ games }: { games: Game[] }) {
   const events = buildTimeline(games)
 
   if (events.length === 0) {
-    return <p className="text-sm text-muted-foreground">No games yet.</p>
+    return <p className="text-base text-muted-foreground">No games yet.</p>
   }
 
   return (
-    <div className="space-y-6">
-      <div className={CARD + " p-4 sm:p-5"}>
-        <h2 className={SECTION_LABEL + " mb-3"}>Table time</h2>
+    <div className="space-y-8">
+      <div className={CARD + " p-5"}>
+        <h2 className={SECTION_LABEL + " mb-1"}>Games played</h2>
+        <p className="mb-4 text-sm text-muted-foreground">Each square is a day — darker means more games at the table.</p>
         <Heatmap events={events} />
       </div>
 
       <div>
-        <h2 className={SECTION_LABEL + " mb-3"}>Recent activity</h2>
+        <h2 className={SECTION_LABEL + " mb-4"}>Recent activity</h2>
         <ul className="relative">
-          <span className="absolute left-[3px] top-2 bottom-2 w-px bg-border" />
+          <span className="absolute left-[4px] top-2 bottom-2 w-px bg-border" />
           {events.map((ev) => (
             <FeedLine key={ev.game.id} event={ev} />
           ))}

--- a/src/components/prototypes/historyTimeline/VariantFeed.tsx
+++ b/src/components/prototypes/historyTimeline/VariantFeed.tsx
@@ -1,0 +1,187 @@
+import { useMemo } from "react"
+import { CARD, SECTION_LABEL } from "@/components/modern/primitives"
+import { cn } from "@/lib/utils"
+import type { Game } from "@/types"
+import { MilestoneBadge } from "./MilestoneBadge"
+import { buildTimeline, opponentsOf, shortCommander, type TimelineEvent } from "./timeline"
+
+// ── Contribution heatmap ─────────────────────────────────────────────────────
+
+function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+}
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate())
+}
+
+function Heatmap({ events }: { events: TimelineEvent[] }) {
+  const { weeks, monthMarks, max } = useMemo(() => {
+    const counts = new Map<string, number>()
+    let max = 0
+    for (const ev of events) {
+      const k = dayKey(ev.date)
+      const n = (counts.get(k) ?? 0) + 1
+      counts.set(k, n)
+      if (n > max) max = n
+    }
+
+    const dates = events.map((e) => startOfDay(e.date).getTime())
+    const last = dates.length ? new Date(Math.max(...dates)) : new Date()
+    const earliest = dates.length ? new Date(Math.min(...dates)) : new Date()
+
+    // start at the Sunday on/before the earliest game (cap at ~20 weeks)
+    const start = startOfDay(earliest)
+    start.setDate(start.getDate() - start.getDay())
+    const end = startOfDay(last)
+    end.setDate(end.getDate() + (6 - end.getDay()))
+    const cap = new Date(end)
+    cap.setDate(cap.getDate() - 20 * 7)
+    if (start < cap) start.setTime(cap.getTime())
+
+    const weeks: { date: Date; count: number }[][] = []
+    const monthMarks: { col: number; label: string }[] = []
+    const cursor = new Date(start)
+    let col = 0
+    let lastMonth = -1
+    while (cursor <= end) {
+      const week: { date: Date; count: number }[] = []
+      for (let i = 0; i < 7; i++) {
+        const d = new Date(cursor)
+        week.push({ date: d, count: counts.get(dayKey(d)) ?? 0 })
+        if (i === 0 && d.getMonth() !== lastMonth) {
+          lastMonth = d.getMonth()
+          monthMarks.push({ col, label: d.toLocaleDateString(undefined, { month: "short" }) })
+        }
+        cursor.setDate(cursor.getDate() + 1)
+      }
+      weeks.push(week)
+      col++
+    }
+    return { weeks, monthMarks, max }
+  }, [events])
+
+  function intensity(count: number): string {
+    if (count <= 0) return "bg-muted/50"
+    const ratio = max <= 1 ? 1 : count / max
+    if (ratio > 0.66) return "bg-primary"
+    if (ratio > 0.33) return "bg-primary/60"
+    return "bg-primary/30"
+  }
+
+  return (
+    <div className="overflow-x-auto no-scrollbar">
+      <div className="inline-block min-w-full">
+        <div className="flex gap-[3px] pl-7">
+          {weeks.map((_, col) => {
+            const mark = monthMarks.find((m) => m.col === col)
+            return (
+              <div key={col} className="w-[12px] text-[9px] text-muted-foreground">
+                {mark?.label ?? ""}
+              </div>
+            )
+          })}
+        </div>
+        <div className="mt-1 flex gap-[3px]">
+          <div className="mr-1 flex flex-col justify-between py-[1px] text-[9px] text-muted-foreground">
+            <span>Mon</span>
+            <span>Wed</span>
+            <span>Fri</span>
+          </div>
+          {weeks.map((week, col) => (
+            <div key={col} className="flex flex-col gap-[3px]">
+              {week.map((cell) => (
+                <div
+                  key={cell.date.toISOString()}
+                  title={`${cell.date.toLocaleDateString()} — ${cell.count} game${cell.count === 1 ? "" : "s"}`}
+                  className={cn("h-[12px] w-[12px] rounded-[2px]", intensity(cell.count))}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Feed ─────────────────────────────────────────────────────────────────────
+
+function relativeTime(date: Date): string {
+  const diff = Date.now() - date.getTime()
+  const day = 1000 * 60 * 60 * 24
+  const days = Math.floor(diff / day)
+  if (days <= 0) return "today"
+  if (days === 1) return "yesterday"
+  if (days < 7) return `${days}d ago`
+  if (days < 30) return `${Math.floor(days / 7)}w ago`
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`
+  return `${Math.floor(days / 365)}y ago`
+}
+
+function FeedLine({ event }: { event: TimelineEvent }) {
+  const { me, won, date, game, milestones } = event
+  const cmdr = shortCommander(me?.commanderName)
+  const opponents = opponentsOf(game)
+
+  return (
+    <li className="flex gap-3">
+      <span
+        className={cn(
+          "mt-1.5 h-2 w-2 shrink-0 rounded-full",
+          won ? "bg-primary" : "bg-muted-foreground/40"
+        )}
+      />
+      <div className="min-w-0 flex-1 pb-4">
+        <p className="text-sm">
+          <span className="font-semibold">{won ? "Won" : "Lost"}</span> with{" "}
+          <span className="font-medium">{cmdr}</span>
+          {won && game.winTurn ? ` on turn ${game.winTurn}` : ""}
+          {opponents.length > 0 ? (
+            <span className="text-muted-foreground"> vs {opponents.join(" · ")}</span>
+          ) : null}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[11px] text-muted-foreground tabular">
+            {relativeTime(date)}
+          </span>
+          {milestones.map((m, i) => (
+            <MilestoneBadge key={i} milestone={m} />
+          ))}
+        </div>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * Variant C — "Activity".
+ * A social-style feed of your play, fronted by a GitHub-style contribution
+ * heatmap so you can feel the rhythm of how often you get to the table.
+ */
+export function VariantFeed({ games }: { games: Game[] }) {
+  const events = buildTimeline(games)
+
+  if (events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No games yet.</p>
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className={CARD + " p-4 sm:p-5"}>
+        <h2 className={SECTION_LABEL + " mb-3"}>Table time</h2>
+        <Heatmap events={events} />
+      </div>
+
+      <div>
+        <h2 className={SECTION_LABEL + " mb-3"}>Recent activity</h2>
+        <ul className="relative">
+          <span className="absolute left-[3px] top-2 bottom-2 w-px bg-border" />
+          {events.map((ev) => (
+            <FeedLine key={ev.game.id} event={ev} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/components/prototypes/historyTimeline/VariantJourney.tsx
+++ b/src/components/prototypes/historyTimeline/VariantJourney.tsx
@@ -1,6 +1,7 @@
 import { Pips, ResultBadge } from "@/components/modern/primitives"
+import { cn } from "@/lib/utils"
 import type { Game } from "@/types"
-import { MilestoneBadge } from "./MilestoneBadge"
+import { MilestoneEvent } from "./MilestoneBadge"
 import {
   buildTimeline,
   colorsOf,
@@ -12,54 +13,49 @@ import {
 
 /**
  * Variant A — "The Journey".
- * A single vertical spine running top-to-bottom. Every game is a node; wins
- * light the node up, milestones bloom as chips beside it. Reads like a metro
- * line of your Commander career, newest at the top.
+ * A vertical spine, newest at the top. Every game is a node; games that hit a
+ * milestone bloom into a highlighted card listing each discrete highlight
+ * (5th win · Krenko, Closed with Craterhoof Behemoth, …).
  */
 function Node({ event }: { event: TimelineEvent }) {
   const { game, me, won, date, careerIndex, milestones } = event
   const colors = colorsOf(me)
   const opponents = opponentsOf(game)
+  const highlight = milestones.length > 0
 
   return (
-    <li className="relative pl-10 pb-7 last:pb-0">
-      {/* spine dot */}
+    <li className="relative pl-12 pb-8 last:pb-0">
       <span
-        className={
-          "absolute left-[14px] top-1.5 z-10 h-3.5 w-3.5 -translate-x-1/2 rounded-full ring-4 ring-background " +
-          (won ? "bg-primary" : "bg-muted-foreground/40")
-        }
+        className={cn(
+          "absolute left-4 top-1.5 z-10 -translate-x-1/2 rounded-full ring-4 ring-background",
+          highlight ? "h-4 w-4 bg-amber-500" : won ? "h-3.5 w-3.5 bg-primary" : "h-3.5 w-3.5 bg-muted-foreground/40"
+        )}
       />
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
         <ResultBadge won={won} />
-        <span className="text-sm font-semibold">{shortCommander(me?.commanderName)}</span>
+        <span className="text-lg font-semibold">{shortCommander(me?.commanderName)}</span>
         {colors.length > 0 && (
           <span className="inline-flex">
             <Pips colors={colors} />
           </span>
         )}
-        <span className="ml-auto font-mono text-[11px] text-muted-foreground tabular">
-          #{careerIndex}
-        </span>
+        <span className="ml-auto font-mono text-sm text-muted-foreground tabular">#{careerIndex}</span>
       </div>
 
-      <div className="mt-1 text-xs text-muted-foreground">
+      <div className="mt-1 text-base text-muted-foreground">
         {opponents.length > 0 ? `vs ${opponents.join(" · ")}` : "Solo log"}
       </div>
 
-      <div className="mt-1 flex flex-wrap items-center gap-2">
-        <span className="font-mono text-[11px] text-muted-foreground tabular">{dayLabel(date)}</span>
-        {game.winTurn ? (
-          <span className="font-mono text-[11px] text-muted-foreground tabular">
-            · {game.winTurn} turns
-          </span>
-        ) : null}
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-sm text-muted-foreground tabular">
+        <span>{dayLabel(date)}</span>
+        {game.winTurn ? <span>{game.winTurn} turns</span> : null}
+        {game.bracket ? <span>bracket {game.bracket}</span> : null}
       </div>
 
-      {milestones.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1.5">
+      {highlight && (
+        <div className="mt-3 space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4">
           {milestones.map((m, i) => (
-            <MilestoneBadge key={i} milestone={m} />
+            <MilestoneEvent key={i} milestone={m} />
           ))}
         </div>
       )}
@@ -71,13 +67,12 @@ export function VariantJourney({ games }: { games: Game[] }) {
   const events = buildTimeline(games)
 
   if (events.length === 0) {
-    return <p className="text-sm text-muted-foreground">No games yet.</p>
+    return <p className="text-base text-muted-foreground">No games yet.</p>
   }
 
   return (
     <ol className="relative">
-      {/* the spine */}
-      <span className="absolute left-[14px] top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
+      <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
       {events.map((ev) => (
         <Node key={ev.game.id} event={ev} />
       ))}

--- a/src/components/prototypes/historyTimeline/VariantJourney.tsx
+++ b/src/components/prototypes/historyTimeline/VariantJourney.tsx
@@ -1,18 +1,26 @@
 import { Fragment, useMemo, useState } from "react"
-import { Pips, ResultBadge } from "@/components/modern/primitives"
+import { Pencil, Trash2 } from "lucide-react"
+import { ResultBadge } from "@/components/modern/primitives"
 import { cn } from "@/lib/utils"
 import type { Game } from "@/types"
+import { CommanderAvatar } from "./CommanderAvatar"
 import { MilestoneEvent } from "./MilestoneBadge"
 import {
   buildTimeline,
-  colorsOf,
   dayLabel,
+  groupIntoPods,
   opponentsOf,
   shortCommander,
   type TimelineEvent,
 } from "./timeline"
 
 type ResultFilter = "All" | "Wins" | "Losses"
+type ViewMode = "date" | "pod"
+
+interface JourneyHandlers {
+  onEditGame?: (id: string) => void
+  onDeleteGame?: (id: string) => void
+}
 
 interface MonthBlock {
   key: string
@@ -71,6 +79,59 @@ function Chip({
   )
 }
 
+function Segmented({
+  value,
+  options,
+  onChange,
+}: {
+  value: string
+  options: { id: string; label: string }[]
+  onChange: (id: string) => void
+}) {
+  return (
+    <div className="inline-flex rounded-md border border-input p-0.5 gap-0.5">
+      {options.map((o) => (
+        <button
+          key={o.id}
+          onClick={() => onChange(o.id)}
+          className={cn(
+            "h-9 px-4 rounded-[8px] text-sm font-medium transition-colors",
+            value === o.id ? "bg-foreground text-background" : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function IconButton({
+  label,
+  onClick,
+  danger,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  danger?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className={cn(
+        "grid h-9 w-9 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        danger ? "hover:text-destructive" : "hover:text-foreground"
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
 function YearDivider({ year }: { year: number }) {
   return (
     <li className="relative pl-12 pb-3 pt-1">
@@ -93,16 +154,8 @@ function MonthHeader({ label, count }: { label: string; count: number }) {
   )
 }
 
-/**
- * Variant A — "The Journey".
- * A vertical spine, newest at the top, sectioned by month with a year divider
- * at each year boundary. Every game is a node; milestone games bloom into a
- * highlighted card. Filter by result or hero — milestones keep their
- * career-wide numbering since the timeline is built before filtering.
- */
-function Node({ event }: { event: TimelineEvent }) {
-  const { game, me, won, date, careerIndex, milestones } = event
-  const colors = colorsOf(me)
+function Node({ event, handlers }: { event: TimelineEvent; handlers: JourneyHandlers }) {
+  const { game, me, won, date, milestones } = event
   const opponents = opponentsOf(game)
   const highlight = milestones.length > 0
 
@@ -114,29 +167,44 @@ function Node({ event }: { event: TimelineEvent }) {
           highlight ? "h-4 w-4 bg-amber-500" : won ? "h-3.5 w-3.5 bg-primary" : "h-3.5 w-3.5 bg-muted-foreground/40"
         )}
       />
-      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
-        <ResultBadge won={won} />
-        <span className="text-lg font-semibold">{shortCommander(me?.commanderName)}</span>
-        {colors.length > 0 && (
-          <span className="inline-flex">
-            <Pips colors={colors} />
-          </span>
-        )}
-        <span className="ml-auto font-mono text-sm text-muted-foreground tabular">#{careerIndex}</span>
-      </div>
-
-      <div className="mt-1 text-base text-muted-foreground">
-        {opponents.length > 0 ? `vs ${opponents.join(" · ")}` : "Solo log"}
-      </div>
-
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-sm text-muted-foreground tabular">
-        <span>{dayLabel(date)}</span>
-        {game.winTurn ? <span>{game.winTurn} turns</span> : null}
-        {game.bracket ? <span>bracket {game.bracket}</span> : null}
+      <div className="flex items-start gap-3">
+        <CommanderAvatar name={me?.commanderName} imageUri={me?.commanderImageUri} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
+            <ResultBadge won={won} />
+            <span className="text-lg font-semibold">{shortCommander(me?.commanderName)}</span>
+          </div>
+          <div className="mt-1 text-base text-muted-foreground">
+            {opponents.length > 0 ? `vs ${opponents.join(" · ")}` : "Solo log"}
+          </div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-sm text-muted-foreground tabular">
+            <span>{dayLabel(date)}</span>
+            {game.winTurn ? <span>{game.winTurn} turns</span> : null}
+            {game.bracket ? <span>bracket {game.bracket}</span> : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          {handlers.onEditGame && (
+            <IconButton label="Edit game" onClick={() => handlers.onEditGame!(game.id)}>
+              <Pencil className="h-4 w-4" />
+            </IconButton>
+          )}
+          {handlers.onDeleteGame && (
+            <IconButton
+              label="Delete game"
+              danger
+              onClick={() => {
+                if (window.confirm("Delete this game?")) handlers.onDeleteGame!(game.id)
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+            </IconButton>
+          )}
+        </div>
       </div>
 
       {highlight && (
-        <div className="mt-3 space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/[0.06] p-4">
+        <div className="ml-12 mt-3 space-y-3 rounded-lg border border-border bg-muted/40 p-4">
           {milestones.map((m, i) => (
             <MilestoneEvent key={i} milestone={m} />
           ))}
@@ -146,7 +214,18 @@ function Node({ event }: { event: TimelineEvent }) {
   )
 }
 
-export function VariantJourney({ games }: { games: Game[] }) {
+function Spine({ events, handlers }: { events: TimelineEvent[]; handlers: JourneyHandlers }) {
+  return (
+    <ol className="relative">
+      <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
+      {events.map((ev) => (
+        <Node key={ev.game.id} event={ev} handlers={handlers} />
+      ))}
+    </ol>
+  )
+}
+
+export function VariantJourney({ games, onEditGame, onDeleteGame }: { games: Game[] } & JourneyHandlers) {
   const allEvents = useMemo(() => buildTimeline(games), [games])
 
   const heroes = useMemo(() => {
@@ -157,6 +236,7 @@ export function VariantJourney({ games }: { games: Game[] }) {
     return [...names].sort((a, b) => a.localeCompare(b))
   }, [allEvents])
 
+  const [viewMode, setViewMode] = useState<ViewMode>("date")
   const [result, setResult] = useState<ResultFilter>("All")
   const [hero, setHero] = useState("all")
 
@@ -172,6 +252,8 @@ export function VariantJourney({ games }: { games: Game[] }) {
   )
 
   const months = useMemo(() => groupIntoMonths(shown), [shown])
+  const pods = useMemo(() => groupIntoPods(shown), [shown])
+  const handlers: JourneyHandlers = { onEditGame, onDeleteGame }
 
   if (allEvents.length === 0) {
     return <p className="text-base text-muted-foreground">No games yet.</p>
@@ -180,13 +262,14 @@ export function VariantJourney({ games }: { games: Game[] }) {
   return (
     <div className="space-y-5">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-2 overflow-x-auto no-scrollbar">
-          {(["All", "Wins", "Losses"] as ResultFilter[]).map((f) => (
-            <Chip key={f} active={result === f} onClick={() => setResult(f)}>
-              {f}
-            </Chip>
-          ))}
-        </div>
+        <Segmented
+          value={viewMode}
+          onChange={(v) => setViewMode(v as ViewMode)}
+          options={[
+            { id: "date", label: "By date" },
+            { id: "pod", label: "By pod" },
+          ]}
+        />
         <select
           value={hero}
           onChange={(e) => setHero(e.target.value)}
@@ -201,11 +284,42 @@ export function VariantJourney({ games }: { games: Game[] }) {
         </select>
       </div>
 
+      <div className="flex items-center gap-2 overflow-x-auto no-scrollbar">
+        {(["All", "Wins", "Losses"] as ResultFilter[]).map((f) => (
+          <Chip key={f} active={result === f} onClick={() => setResult(f)}>
+            {f}
+          </Chip>
+        ))}
+      </div>
+
       {shown.length === 0 ? (
         <div className="rounded-lg border border-border bg-card py-12 text-center">
           <div className="text-base font-medium">No games match</div>
           <div className="mt-1 text-sm text-muted-foreground">Try a different filter.</div>
         </div>
+      ) : viewMode === "pod" ? (
+        pods.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card py-12 text-center">
+            <div className="text-base font-medium">No pods to show</div>
+            <div className="mt-1 text-sm text-muted-foreground">
+              Pods form once every seat in a game is named.
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-8">
+            {pods.map((pod) => (
+              <section key={pod.key}>
+                <div className="mb-3 flex items-baseline justify-between gap-3">
+                  <h3 className="truncate text-lg font-semibold tracking-tight">{pod.label}</h3>
+                  <span className="shrink-0 font-mono text-sm text-muted-foreground tabular">
+                    {pod.wins}–{pod.games - pod.wins}
+                  </span>
+                </div>
+                <Spine events={pod.events} handlers={handlers} />
+              </section>
+            ))}
+          </div>
+        )
       ) : (
         <>
           <ol className="relative">
@@ -215,7 +329,7 @@ export function VariantJourney({ games }: { games: Game[] }) {
                 {block.showYear && <YearDivider year={block.year} />}
                 <MonthHeader label={block.month} count={block.events.length} />
                 {block.events.map((ev) => (
-                  <Node key={ev.game.id} event={ev} />
+                  <Node key={ev.game.id} event={ev} handlers={handlers} />
                 ))}
               </Fragment>
             ))}

--- a/src/components/prototypes/historyTimeline/VariantJourney.tsx
+++ b/src/components/prototypes/historyTimeline/VariantJourney.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react"
 import { Pips, ResultBadge } from "@/components/modern/primitives"
 import { cn } from "@/lib/utils"
 import type { Game } from "@/types"
@@ -11,11 +12,38 @@ import {
   type TimelineEvent,
 } from "./timeline"
 
+type ResultFilter = "All" | "Wins" | "Losses"
+
+function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "h-9 px-4 rounded-full text-sm font-medium whitespace-nowrap shrink-0 transition-colors",
+        active
+          ? "bg-foreground text-background"
+          : "border border-border text-muted-foreground hover:text-foreground hover:bg-muted"
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
 /**
  * Variant A — "The Journey".
  * A vertical spine, newest at the top. Every game is a node; games that hit a
- * milestone bloom into a highlighted card listing each discrete highlight
- * (5th win · Krenko, Closed with Craterhoof Behemoth, …).
+ * milestone bloom into a highlighted card listing each discrete highlight.
+ * Filter by result or hero — milestones keep their career-wide numbering since
+ * they're computed over the full timeline before filtering.
  */
 function Node({ event }: { event: TimelineEvent }) {
   const { game, me, won, date, careerIndex, milestones } = event
@@ -64,18 +92,76 @@ function Node({ event }: { event: TimelineEvent }) {
 }
 
 export function VariantJourney({ games }: { games: Game[] }) {
-  const events = buildTimeline(games)
+  const allEvents = useMemo(() => buildTimeline(games), [games])
 
-  if (events.length === 0) {
+  const heroes = useMemo(() => {
+    const names = new Set<string>()
+    for (const ev of allEvents) {
+      if (ev.me?.commanderName) names.add(ev.me.commanderName)
+    }
+    return [...names].sort((a, b) => a.localeCompare(b))
+  }, [allEvents])
+
+  const [result, setResult] = useState<ResultFilter>("All")
+  const [hero, setHero] = useState("all")
+
+  const shown = useMemo(
+    () =>
+      allEvents.filter((ev) => {
+        if (result === "Wins" && !ev.won) return false
+        if (result === "Losses" && ev.won) return false
+        if (hero !== "all" && ev.me?.commanderName !== hero) return false
+        return true
+      }),
+    [allEvents, result, hero]
+  )
+
+  if (allEvents.length === 0) {
     return <p className="text-base text-muted-foreground">No games yet.</p>
   }
 
   return (
-    <ol className="relative">
-      <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
-      {events.map((ev) => (
-        <Node key={ev.game.id} event={ev} />
-      ))}
-    </ol>
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 overflow-x-auto no-scrollbar">
+          {(["All", "Wins", "Losses"] as ResultFilter[]).map((f) => (
+            <Chip key={f} active={result === f} onClick={() => setResult(f)}>
+              {f}
+            </Chip>
+          ))}
+        </div>
+        <select
+          value={hero}
+          onChange={(e) => setHero(e.target.value)}
+          className="h-10 rounded-md border border-input bg-card px-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <option value="all">All heroes</option>
+          {heroes.map((name) => (
+            <option key={name} value={name}>
+              {shortCommander(name)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {shown.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card py-12 text-center">
+          <div className="text-base font-medium">No games match</div>
+          <div className="mt-1 text-sm text-muted-foreground">Try a different filter.</div>
+        </div>
+      ) : (
+        <>
+          <ol className="relative">
+            <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
+            {shown.map((ev) => (
+              <Node key={ev.game.id} event={ev} />
+            ))}
+          </ol>
+          <div className="text-center font-mono text-sm text-muted-foreground tabular">
+            showing {shown.length} of {allEvents.length} games
+          </div>
+        </>
+      )}
+    </div>
   )
 }

--- a/src/components/prototypes/historyTimeline/VariantJourney.tsx
+++ b/src/components/prototypes/historyTimeline/VariantJourney.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { Fragment, useMemo, useState } from "react"
 import { Pips, ResultBadge } from "@/components/modern/primitives"
 import { cn } from "@/lib/utils"
 import type { Game } from "@/types"
@@ -13,6 +13,39 @@ import {
 } from "./timeline"
 
 type ResultFilter = "All" | "Wins" | "Losses"
+
+interface MonthBlock {
+  key: string
+  month: string
+  year: number
+  showYear: boolean
+  events: TimelineEvent[]
+}
+
+function groupIntoMonths(events: TimelineEvent[]): MonthBlock[] {
+  const blocks: MonthBlock[] = []
+  for (const ev of events) {
+    const key = `${ev.date.getFullYear()}-${ev.date.getMonth()}`
+    let block = blocks[blocks.length - 1]
+    if (!block || block.key !== key) {
+      block = {
+        key,
+        month: ev.date.toLocaleDateString(undefined, { month: "long" }),
+        year: ev.date.getFullYear(),
+        showYear: false,
+        events: [],
+      }
+      blocks.push(block)
+    }
+    block.events.push(ev)
+  }
+  let prevYear: number | null = null
+  for (const block of blocks) {
+    block.showYear = block.year !== prevYear
+    prevYear = block.year
+  }
+  return blocks
+}
 
 function Chip({
   active,
@@ -38,12 +71,34 @@ function Chip({
   )
 }
 
+function YearDivider({ year }: { year: number }) {
+  return (
+    <li className="relative pl-12 pb-3 pt-1">
+      <span className="absolute left-4 top-2.5 z-10 h-3.5 w-3.5 -translate-x-1/2 rounded-full bg-foreground ring-4 ring-background" />
+      <div className="font-mono text-base font-semibold uppercase tracking-[0.2em]">{year}</div>
+    </li>
+  )
+}
+
+function MonthHeader({ label, count }: { label: string; count: number }) {
+  return (
+    <li className="sticky top-0 z-20 -mx-1 bg-background/90 px-1 py-2 backdrop-blur">
+      <div className="flex items-baseline justify-between pl-12">
+        <span className="text-lg font-semibold tracking-tight">{label}</span>
+        <span className="font-mono text-sm text-muted-foreground tabular">
+          {count} {count === 1 ? "game" : "games"}
+        </span>
+      </div>
+    </li>
+  )
+}
+
 /**
  * Variant A — "The Journey".
- * A vertical spine, newest at the top. Every game is a node; games that hit a
- * milestone bloom into a highlighted card listing each discrete highlight.
- * Filter by result or hero — milestones keep their career-wide numbering since
- * they're computed over the full timeline before filtering.
+ * A vertical spine, newest at the top, sectioned by month with a year divider
+ * at each year boundary. Every game is a node; milestone games bloom into a
+ * highlighted card. Filter by result or hero — milestones keep their
+ * career-wide numbering since the timeline is built before filtering.
  */
 function Node({ event }: { event: TimelineEvent }) {
   const { game, me, won, date, careerIndex, milestones } = event
@@ -116,6 +171,8 @@ export function VariantJourney({ games }: { games: Game[] }) {
     [allEvents, result, hero]
   )
 
+  const months = useMemo(() => groupIntoMonths(shown), [shown])
+
   if (allEvents.length === 0) {
     return <p className="text-base text-muted-foreground">No games yet.</p>
   }
@@ -153,8 +210,14 @@ export function VariantJourney({ games }: { games: Game[] }) {
         <>
           <ol className="relative">
             <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
-            {shown.map((ev) => (
-              <Node key={ev.game.id} event={ev} />
+            {months.map((block) => (
+              <Fragment key={block.key}>
+                {block.showYear && <YearDivider year={block.year} />}
+                <MonthHeader label={block.month} count={block.events.length} />
+                {block.events.map((ev) => (
+                  <Node key={ev.game.id} event={ev} />
+                ))}
+              </Fragment>
             ))}
           </ol>
           <div className="text-center font-mono text-sm text-muted-foreground tabular">

--- a/src/components/prototypes/historyTimeline/VariantJourney.tsx
+++ b/src/components/prototypes/historyTimeline/VariantJourney.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useMemo, useState } from "react"
-import { Pencil, Trash2 } from "lucide-react"
-import { ResultBadge } from "@/components/modern/primitives"
+import { Check, Pencil, Trash2, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { Game } from "@/types"
 import { CommanderAvatar } from "./CommanderAvatar"
@@ -135,7 +134,7 @@ function IconButton({
 function YearDivider({ year }: { year: number }) {
   return (
     <li className="relative pl-12 pb-3 pt-1">
-      <span className="absolute left-4 top-2.5 z-10 h-3.5 w-3.5 -translate-x-1/2 rounded-full bg-foreground ring-4 ring-background" />
+      <span className="absolute left-4 top-2.5 z-40 h-3.5 w-3.5 -translate-x-1/2 rounded-full bg-foreground ring-4 ring-background" />
       <div className="font-mono text-base font-semibold uppercase tracking-[0.2em]">{year}</div>
     </li>
   )
@@ -162,17 +161,20 @@ function Node({ event, handlers }: { event: TimelineEvent; handlers: JourneyHand
   return (
     <li className="relative pl-12 pb-8 last:pb-0">
       <span
+        title={won ? "Win" : "Loss"}
         className={cn(
-          "absolute left-4 top-1.5 z-10 -translate-x-1/2 rounded-full ring-4 ring-background",
-          highlight ? "h-4 w-4 bg-amber-500" : won ? "h-3.5 w-3.5 bg-primary" : "h-3.5 w-3.5 bg-muted-foreground/40"
+          "absolute left-4 top-0.5 z-40 grid h-7 w-7 -translate-x-1/2 place-items-center rounded-full ring-4 ring-background",
+          won ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
         )}
-      />
+      >
+        {won ? <Check className="h-4 w-4" /> : <X className="h-4 w-4" />}
+      </span>
       <div className="flex items-start gap-3">
         <CommanderAvatar name={me?.commanderName} imageUri={me?.commanderImageUri} />
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
-            <ResultBadge won={won} />
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <span className="text-lg font-semibold">{shortCommander(me?.commanderName)}</span>
+            {highlight && <span className="h-2 w-2 rounded-full bg-amber-500" title="Has highlights" />}
           </div>
           <div className="mt-1 text-base text-muted-foreground">
             {opponents.length > 0 ? `vs ${opponents.join(" · ")}` : "Solo log"}
@@ -217,7 +219,7 @@ function Node({ event, handlers }: { event: TimelineEvent; handlers: JourneyHand
 function Spine({ events, handlers }: { events: TimelineEvent[]; handlers: JourneyHandlers }) {
   return (
     <ol className="relative">
-      <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
+      <span className="pointer-events-none absolute left-4 top-2 bottom-2 z-30 w-px -translate-x-1/2 bg-border" />
       {events.map((ev) => (
         <Node key={ev.game.id} event={ev} handlers={handlers} />
       ))}
@@ -323,7 +325,7 @@ export function VariantJourney({ games, onEditGame, onDeleteGame }: { games: Gam
       ) : (
         <>
           <ol className="relative">
-            <span className="absolute left-4 top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
+            <span className="pointer-events-none absolute left-4 top-2 bottom-2 z-30 w-px -translate-x-1/2 bg-border" />
             {months.map((block) => (
               <Fragment key={block.key}>
                 {block.showYear && <YearDivider year={block.year} />}

--- a/src/components/prototypes/historyTimeline/VariantJourney.tsx
+++ b/src/components/prototypes/historyTimeline/VariantJourney.tsx
@@ -1,0 +1,86 @@
+import { Pips, ResultBadge } from "@/components/modern/primitives"
+import type { Game } from "@/types"
+import { MilestoneBadge } from "./MilestoneBadge"
+import {
+  buildTimeline,
+  colorsOf,
+  dayLabel,
+  opponentsOf,
+  shortCommander,
+  type TimelineEvent,
+} from "./timeline"
+
+/**
+ * Variant A — "The Journey".
+ * A single vertical spine running top-to-bottom. Every game is a node; wins
+ * light the node up, milestones bloom as chips beside it. Reads like a metro
+ * line of your Commander career, newest at the top.
+ */
+function Node({ event }: { event: TimelineEvent }) {
+  const { game, me, won, date, careerIndex, milestones } = event
+  const colors = colorsOf(me)
+  const opponents = opponentsOf(game)
+
+  return (
+    <li className="relative pl-10 pb-7 last:pb-0">
+      {/* spine dot */}
+      <span
+        className={
+          "absolute left-[14px] top-1.5 z-10 h-3.5 w-3.5 -translate-x-1/2 rounded-full ring-4 ring-background " +
+          (won ? "bg-primary" : "bg-muted-foreground/40")
+        }
+      />
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <ResultBadge won={won} />
+        <span className="text-sm font-semibold">{shortCommander(me?.commanderName)}</span>
+        {colors.length > 0 && (
+          <span className="inline-flex">
+            <Pips colors={colors} />
+          </span>
+        )}
+        <span className="ml-auto font-mono text-[11px] text-muted-foreground tabular">
+          #{careerIndex}
+        </span>
+      </div>
+
+      <div className="mt-1 text-xs text-muted-foreground">
+        {opponents.length > 0 ? `vs ${opponents.join(" · ")}` : "Solo log"}
+      </div>
+
+      <div className="mt-1 flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[11px] text-muted-foreground tabular">{dayLabel(date)}</span>
+        {game.winTurn ? (
+          <span className="font-mono text-[11px] text-muted-foreground tabular">
+            · {game.winTurn} turns
+          </span>
+        ) : null}
+      </div>
+
+      {milestones.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {milestones.map((m, i) => (
+            <MilestoneBadge key={i} milestone={m} />
+          ))}
+        </div>
+      )}
+    </li>
+  )
+}
+
+export function VariantJourney({ games }: { games: Game[] }) {
+  const events = buildTimeline(games)
+
+  if (events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No games yet.</p>
+  }
+
+  return (
+    <ol className="relative">
+      {/* the spine */}
+      <span className="absolute left-[14px] top-2 bottom-2 w-px -translate-x-1/2 bg-border" />
+      {events.map((ev) => (
+        <Node key={ev.game.id} event={ev} />
+      ))}
+    </ol>
+  )
+}

--- a/src/components/prototypes/historyTimeline/sampleGames.ts
+++ b/src/components/prototypes/historyTimeline/sampleGames.ts
@@ -63,26 +63,28 @@ function id(seed: number): string {
  * wincon cards, brackets, fast mana, knockouts — so the timeline highlights and
  * the heatmap have realistic material to surface.
  */
-// 40-game W/L pattern with deliberate win and loss streaks.
-const RESULTS = "WLWWLWLLWWWLLLWLWWLWWWLLWLWWLLLWLWWLWLWWW"
+// 40-game W/L pattern with deliberate win and loss streaks, plus one undefeated
+// month (games 12-14) so the "flawless month" highlight fires.
+const RESULTS = "WLWWLWLLWWWLWWWLWWLWWWLLWLWWLLLWLWWLWLWWW"
 
 export function buildSampleGames(): Game[] {
   const games: Game[] = []
-  // Start in late 2025 so the career crosses a year boundary (shows a year divider).
-  const start = new Date("2025-10-03T19:30:00")
-  let cursor = start.getTime()
+  // Three games per calendar month starting Oct 2025 — so the career crosses a
+  // year boundary and each month maps cleanly to a 3-game block.
+  const base = new Date(2025, 9, 1)
 
   for (let i = 0; i < RESULTS.length; i++) {
     // Bias toward Krenko (deck 0) so it reaches the 10- and 20-game veteran tiers.
     const deckIndex = i % 7 < 4 ? 0 : (i % 7) - 3
     const deck = MY_DECKS[deckIndex]
     const playerCount = 3 + (i % 2) // alternate 3- and 4-player pods
-    cursor += 1000 * 60 * 60 * 24 * (4 + (i % 5))
-    const playedAt = new Date(cursor)
+    const monthIndex = Math.floor(i / 3)
+    const playedAt = new Date(base.getFullYear(), base.getMonth() + monthIndex, 5 + (i % 3) * 9, 19, 30)
     const meId = id(i * 100)
     const opponentNames = OPPONENTS.slice(i % 4, (i % 4) + playerCount - 1)
     const won = RESULTS[i] === "W"
-    const winTurn = won ? 4 + (i % 5) : 8 + (i % 3)
+    // win turns span fast kills (4-5) through grindy 12+ games
+    const winTurn = won ? 4 + (i % 9) : 8 + (i % 3)
     const usedFastMana = i % 5 === 0
     const opponentHasFastMana = i % 4 === 2 // some pods race out a fast-mana start
 

--- a/src/components/prototypes/historyTimeline/sampleGames.ts
+++ b/src/components/prototypes/historyTimeline/sampleGames.ts
@@ -1,15 +1,43 @@
-import type { Game, MtgColor } from "@/types"
+import type { Game, MtgColor, Player } from "@/types"
 
 interface Deck {
   name: string
   colors: MtgColor[]
+  bracket: number
+  /** Cards this deck tends to win with — surfaced as "Closed with …". */
+  wincons: string[]
+  winCondition: string
 }
 
 const MY_DECKS: Deck[] = [
-  { name: "Atraxa, Praetors' Voice", colors: ["W", "U", "B", "G"] },
-  { name: "Krenko, Mob Boss", colors: ["R"] },
-  { name: "Yuriko, the Tiger's Shadow", colors: ["U", "B"] },
-  { name: "Lathril, Blade of the Elves", colors: ["B", "G"] },
+  {
+    name: "Krenko, Mob Boss",
+    colors: ["R"],
+    bracket: 3,
+    wincons: ["Impact Tremors", "Purphoros, God of the Forge", "Skullclamp"],
+    winCondition: "Lethal Non-Combat Damage",
+  },
+  {
+    name: "Lathril, Blade of the Elves",
+    colors: ["B", "G"],
+    bracket: 3,
+    wincons: ["Craterhoof Behemoth", "Beastmaster Ascension", "Lathril, Blade of the Elves"],
+    winCondition: "Lethal Combat Damage",
+  },
+  {
+    name: "Yuriko, the Tiger's Shadow",
+    colors: ["U", "B"],
+    bracket: 4,
+    wincons: ["Yuriko, the Tiger's Shadow", "Fireball", "Temporal Trespass"],
+    winCondition: "Commander Damage",
+  },
+  {
+    name: "Atraxa, Praetors' Voice",
+    colors: ["W", "U", "B", "G"],
+    bracket: 4,
+    wincons: ["Thassa's Oracle", "Demonic Consultation", "Toxic Deluge"],
+    winCondition: "Infinite Loop",
+  },
 ]
 
 const OPPONENTS = [
@@ -18,10 +46,12 @@ const OPPONENTS = [
   "Najeela, the Blade-Blossom",
   "Korvold, Fae-Cursed King",
   "Urza, Lord High Artificer",
-  "Tymna",
+  "Tymna the Weaver",
   "Prosper, Tome-Bound",
   "Magda, Brazen Outlaw",
 ]
+
+const FAST_MANA = ["Sol Ring", "Mana Crypt", "Jeweled Lotus", "Mana Vault"]
 
 function id(seed: number): string {
   return `proto-${seed.toString(36)}-${(seed * 7919).toString(36)}`
@@ -29,53 +59,59 @@ function id(seed: number): string {
 
 /**
  * Deterministic sample career used by the prototype harness when the signed-in
- * user has no real games yet. Spans ~4 months with streaks and deck debuts so
- * the timeline milestones have something to surface.
+ * user has no real games yet. ~4 months of in-depth logs — win conditions, key
+ * wincon cards, brackets, fast mana, knockouts — so the timeline highlights and
+ * the heatmap have realistic material to surface.
  */
 export function buildSampleGames(): Game[] {
   const games: Game[] = []
   const start = new Date("2026-02-08T19:30:00")
-  // win pattern crafted to produce a debut, a first win, and a 3-game streak
+  // crafted to produce a debut, a first win, a 3-win streak, and a fast kill
   const wins = [false, true, false, true, true, true, false, false, true, false, true, false, true, true]
   const deckOrder = [0, 0, 1, 1, 0, 2, 2, 1, 0, 3, 3, 2, 0, 1]
 
   for (let i = 0; i < wins.length; i++) {
     const deck = MY_DECKS[deckOrder[i]]
-    const playerCount = 3 + (i % 2) // alternate 3 and 4 player pods
-    const playedAt = new Date(start.getTime() + i * 1000 * 60 * 60 * 24 * (8 + (i % 3)))
+    const playerCount = 3 + (i % 2) // alternate 3- and 4-player pods
+    const playedAt = new Date(start.getTime() + i * 1000 * 60 * 60 * 24 * (5 + (i % 4)))
     const meId = id(i * 100)
-    const opponents = OPPONENTS.slice(i % 4, (i % 4) + playerCount - 1)
-
-    const players = [
-      {
-        id: meId,
-        isMe: true,
-        commanderName: deck.name,
-        commanderColorIdentity: deck.colors,
-        seatPosition: ((i % playerCount) + 1) as Game["players"][number]["seatPosition"],
-        displayName: "You",
-        fastMana: { hasFastMana: i % 4 === 0, cards: i % 4 === 0 ? ["Sol Ring"] : [] },
-      },
-      ...opponents.map((name, j) => ({
-        id: id(i * 100 + j + 1),
-        isMe: false,
-        commanderName: name,
-        seatPosition: (j + 2) as Game["players"][number]["seatPosition"],
-        displayName: name.split(/[ ,]/)[0],
-        fastMana: { hasFastMana: false, cards: [] },
-      })),
-    ]
-
+    const opponentNames = OPPONENTS.slice(i % 4, (i % 4) + playerCount - 1)
     const won = wins[i]
-    const winnerId = won ? meId : players[1].id
+    const winTurn = won ? 4 + (i % 5) : 8 + (i % 4)
+    const usedFastMana = i % 3 === 0
+
+    const me: Player = {
+      id: meId,
+      isMe: true,
+      commanderName: deck.name,
+      commanderColorIdentity: deck.colors,
+      seatPosition: ((i % playerCount) + 1) as Player["seatPosition"],
+      displayName: "You",
+      fastMana: { hasFastMana: usedFastMana, cards: usedFastMana ? [FAST_MANA[i % FAST_MANA.length]] : [] },
+    }
+
+    const opponents: Player[] = opponentNames.map((name, j) => ({
+      id: id(i * 100 + j + 1),
+      isMe: false,
+      commanderName: name,
+      seatPosition: (j + 2) as Player["seatPosition"],
+      displayName: name.split(/[ ,]/)[0],
+      knockoutTurn: won ? winTurn - (j + 1) : undefined,
+      fastMana: { hasFastMana: false, cards: [] },
+    }))
+
+    const players = [me, ...opponents]
+    const winnerId = won ? meId : opponents[0].id
 
     games.push({
       id: id(i),
       playedAt: playedAt.toISOString(),
       players,
       winnerId,
-      winTurn: won ? 4 + (i % 6) : 7 + (i % 5),
-      winConditions: won ? ["Combat damage"] : undefined,
+      winTurn,
+      bracket: deck.bracket,
+      winConditions: won ? [deck.winCondition] : undefined,
+      keyWinconCards: won ? [deck.wincons[i % deck.wincons.length]] : undefined,
     })
   }
 

--- a/src/components/prototypes/historyTimeline/sampleGames.ts
+++ b/src/components/prototypes/historyTimeline/sampleGames.ts
@@ -1,0 +1,83 @@
+import type { Game, MtgColor } from "@/types"
+
+interface Deck {
+  name: string
+  colors: MtgColor[]
+}
+
+const MY_DECKS: Deck[] = [
+  { name: "Atraxa, Praetors' Voice", colors: ["W", "U", "B", "G"] },
+  { name: "Krenko, Mob Boss", colors: ["R"] },
+  { name: "Yuriko, the Tiger's Shadow", colors: ["U", "B"] },
+  { name: "Lathril, Blade of the Elves", colors: ["B", "G"] },
+]
+
+const OPPONENTS = [
+  "Edgar Markov",
+  "Kaalia of the Vast",
+  "Najeela, the Blade-Blossom",
+  "Korvold, Fae-Cursed King",
+  "Urza, Lord High Artificer",
+  "Tymna",
+  "Prosper, Tome-Bound",
+  "Magda, Brazen Outlaw",
+]
+
+function id(seed: number): string {
+  return `proto-${seed.toString(36)}-${(seed * 7919).toString(36)}`
+}
+
+/**
+ * Deterministic sample career used by the prototype harness when the signed-in
+ * user has no real games yet. Spans ~4 months with streaks and deck debuts so
+ * the timeline milestones have something to surface.
+ */
+export function buildSampleGames(): Game[] {
+  const games: Game[] = []
+  const start = new Date("2026-02-08T19:30:00")
+  // win pattern crafted to produce a debut, a first win, and a 3-game streak
+  const wins = [false, true, false, true, true, true, false, false, true, false, true, false, true, true]
+  const deckOrder = [0, 0, 1, 1, 0, 2, 2, 1, 0, 3, 3, 2, 0, 1]
+
+  for (let i = 0; i < wins.length; i++) {
+    const deck = MY_DECKS[deckOrder[i]]
+    const playerCount = 3 + (i % 2) // alternate 3 and 4 player pods
+    const playedAt = new Date(start.getTime() + i * 1000 * 60 * 60 * 24 * (8 + (i % 3)))
+    const meId = id(i * 100)
+    const opponents = OPPONENTS.slice(i % 4, (i % 4) + playerCount - 1)
+
+    const players = [
+      {
+        id: meId,
+        isMe: true,
+        commanderName: deck.name,
+        commanderColorIdentity: deck.colors,
+        seatPosition: ((i % playerCount) + 1) as Game["players"][number]["seatPosition"],
+        displayName: "You",
+        fastMana: { hasFastMana: i % 4 === 0, cards: i % 4 === 0 ? ["Sol Ring"] : [] },
+      },
+      ...opponents.map((name, j) => ({
+        id: id(i * 100 + j + 1),
+        isMe: false,
+        commanderName: name,
+        seatPosition: (j + 2) as Game["players"][number]["seatPosition"],
+        displayName: name.split(/[ ,]/)[0],
+        fastMana: { hasFastMana: false, cards: [] },
+      })),
+    ]
+
+    const won = wins[i]
+    const winnerId = won ? meId : players[1].id
+
+    games.push({
+      id: id(i),
+      playedAt: playedAt.toISOString(),
+      players,
+      winnerId,
+      winTurn: won ? 4 + (i % 6) : 7 + (i % 5),
+      winConditions: won ? ["Combat damage"] : undefined,
+    })
+  }
+
+  return games
+}

--- a/src/components/prototypes/historyTimeline/sampleGames.ts
+++ b/src/components/prototypes/historyTimeline/sampleGames.ts
@@ -87,6 +87,7 @@ export function buildSampleGames(): Game[] {
       commanderColorIdentity: deck.colors,
       seatPosition: ((i % playerCount) + 1) as Player["seatPosition"],
       displayName: "You",
+      knockoutTurn: won ? undefined : Math.max(3, winTurn - 3 - (i % 3)),
       fastMana: { hasFastMana: usedFastMana, cards: usedFastMana ? [FAST_MANA[i % FAST_MANA.length]] : [] },
     }
 

--- a/src/components/prototypes/historyTimeline/sampleGames.ts
+++ b/src/components/prototypes/historyTimeline/sampleGames.ts
@@ -63,31 +63,37 @@ function id(seed: number): string {
  * wincon cards, brackets, fast mana, knockouts — so the timeline highlights and
  * the heatmap have realistic material to surface.
  */
+// 40-game W/L pattern with deliberate win and loss streaks.
+const RESULTS = "WLWWLWLLWWWLLLWLWWLWWWLLWLWWLLLWLWWLWLWWW"
+
 export function buildSampleGames(): Game[] {
   const games: Game[] = []
-  const start = new Date("2026-02-08T19:30:00")
-  // crafted to produce a debut, a first win, a 3-win streak, and a fast kill
-  const wins = [false, true, false, true, true, true, false, false, true, false, true, false, true, true]
-  const deckOrder = [0, 0, 1, 1, 0, 2, 2, 1, 0, 3, 3, 2, 0, 1]
+  // Start in late 2025 so the career crosses a year boundary (shows a year divider).
+  const start = new Date("2025-10-03T19:30:00")
+  let cursor = start.getTime()
 
-  for (let i = 0; i < wins.length; i++) {
-    const deck = MY_DECKS[deckOrder[i]]
+  for (let i = 0; i < RESULTS.length; i++) {
+    // Bias toward Krenko (deck 0) so it reaches the 10- and 20-game veteran tiers.
+    const deckIndex = i % 7 < 4 ? 0 : (i % 7) - 3
+    const deck = MY_DECKS[deckIndex]
     const playerCount = 3 + (i % 2) // alternate 3- and 4-player pods
-    const playedAt = new Date(start.getTime() + i * 1000 * 60 * 60 * 24 * (5 + (i % 4)))
+    cursor += 1000 * 60 * 60 * 24 * (4 + (i % 5))
+    const playedAt = new Date(cursor)
     const meId = id(i * 100)
     const opponentNames = OPPONENTS.slice(i % 4, (i % 4) + playerCount - 1)
-    const won = wins[i]
-    const winTurn = won ? 4 + (i % 5) : 8 + (i % 4)
-    const usedFastMana = i % 3 === 0
+    const won = RESULTS[i] === "W"
+    const winTurn = won ? 4 + (i % 5) : 8 + (i % 3)
+    const usedFastMana = i % 5 === 0
+    const opponentHasFastMana = i % 4 === 2 // some pods race out a fast-mana start
 
     const me: Player = {
       id: meId,
       isMe: true,
       commanderName: deck.name,
       commanderColorIdentity: deck.colors,
-      seatPosition: ((i % playerCount) + 1) as Player["seatPosition"],
+      seatPosition: ((i % 4) + 1) as Player["seatPosition"], // cycle seats 1-4
       displayName: "You",
-      knockoutTurn: won ? undefined : Math.max(3, winTurn - 3 - (i % 3)),
+      knockoutTurn: won ? undefined : Math.max(3, winTurn - 3 - (i % 4)),
       fastMana: { hasFastMana: usedFastMana, cards: usedFastMana ? [FAST_MANA[i % FAST_MANA.length]] : [] },
     }
 
@@ -98,7 +104,10 @@ export function buildSampleGames(): Game[] {
       seatPosition: (j + 2) as Player["seatPosition"],
       displayName: name.split(/[ ,]/)[0],
       knockoutTurn: won ? winTurn - (j + 1) : undefined,
-      fastMana: { hasFastMana: false, cards: [] },
+      fastMana:
+        j === 0 && opponentHasFastMana
+          ? { hasFastMana: true, cards: [FAST_MANA[(i + 1) % FAST_MANA.length]] }
+          : { hasFastMana: false, cards: [] },
     }))
 
     const players = [me, ...opponents]

--- a/src/components/prototypes/historyTimeline/timeline.ts
+++ b/src/components/prototypes/historyTimeline/timeline.ts
@@ -6,12 +6,16 @@ export type MilestoneKind =
   | "first-game"
   | "milestone-game"
   | "debut"
+  | "veteran"
   | "first-win"
   | "win"
   | "streak"
   | "fast-win"
   | "wincon"
+  | "tough-seat"
+  | "underdog"
   | "knockout"
+  | "loss-streak"
 
 export interface Milestone {
   kind: MilestoneKind
@@ -19,7 +23,17 @@ export interface Milestone {
   label: string
   /** Supporting context, e.g. "Krenko, Mob Boss". */
   detail?: string
+  /** Optional emoji shown instead of the kind's lucide icon. */
+  emoji?: string
 }
+
+/** Per-commander play-count tiers — "veteran status" for a deck you keep bringing. */
+const VETERAN_TIERS: { n: number; emoji: string; detail: string }[] = [
+  { n: 10, emoji: "🧒", detail: "Getting comfortable" },
+  { n: 20, emoji: "🧑", detail: "Seasoned pilot" },
+  { n: 50, emoji: "🧓", detail: "Grizzled veteran" },
+  { n: 100, emoji: "🧙", detail: "True master" },
+]
 
 export interface TimelineEvent {
   game: Game
@@ -52,9 +66,10 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
     (a, b) => new Date(a.playedAt).getTime() - new Date(b.playedAt).getTime()
   )
 
-  const seenCommanders = new Set<string>()
+  const commanderPlays = new Map<string, number>()
   let winCount = 0
   let streak = 0
+  let lossStreak = 0
 
   const events: TimelineEvent[] = chrono.map((game, i) => {
     const me = game.players.find((p) => p.isMe)
@@ -63,17 +78,21 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
     const cmdr = shortCommander(me?.commanderName)
     const milestones: Milestone[] = []
 
+    const playCount = (commanderPlays.get(me?.commanderName ?? "") ?? 0) + 1
+    if (me?.commanderName) commanderPlays.set(me.commanderName, playCount)
+
     if (careerIndex === 1) {
       milestones.push({ kind: "first-game", label: "First game logged", detail: cmdr })
     } else if (GAME_LANDMARKS.has(careerIndex)) {
       milestones.push({ kind: "milestone-game", label: `${ordinal(careerIndex)} game played`, detail: cmdr })
     }
 
-    if (me?.commanderName && !seenCommanders.has(me.commanderName)) {
-      if (seenCommanders.size > 0) {
-        milestones.push({ kind: "debut", label: `${cmdr} debut`, detail: "First time piloting this deck" })
-      }
-      seenCommanders.add(me.commanderName)
+    if (me?.commanderName && playCount === 1 && careerIndex > 1) {
+      milestones.push({ kind: "debut", emoji: "👶", label: `${cmdr} debut`, detail: "First time piloting this deck" })
+    }
+    const tier = VETERAN_TIERS.find((t) => t.n === playCount)
+    if (tier && me?.commanderName) {
+      milestones.push({ kind: "veteran", emoji: tier.emoji, label: `${ordinal(playCount)} game with ${cmdr}`, detail: tier.detail })
     }
 
     let winNumber: number | null = null
@@ -81,6 +100,7 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       winCount += 1
       winNumber = winCount
       streak += 1
+      lossStreak = 0
 
       if (winCount === 1) {
         milestones.push({ kind: "first-win", label: "First win", detail: cmdr })
@@ -91,6 +111,15 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       if (streak >= 2) {
         milestones.push({ kind: "streak", label: `${streak}-win streak` })
       }
+      if (me && me.seatPosition >= 3) {
+        milestones.push({ kind: "tough-seat", emoji: "🎯", label: `Won from seat ${me.seatPosition}`, detail: "Back-of-the-table win" })
+      }
+      const beatFastMana =
+        !me?.fastMana?.hasFastMana &&
+        game.players.some((p) => !p.isMe && p.fastMana?.hasFastMana)
+      if (beatFastMana) {
+        milestones.push({ kind: "underdog", emoji: "🐢", label: "Beat a fast-mana start", detail: "No fast mana of your own" })
+      }
       if (game.winTurn && game.winTurn <= 5) {
         milestones.push({ kind: "fast-win", label: `Turn-${game.winTurn} kill`, detail: cmdr })
       }
@@ -99,6 +128,10 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       }
     } else {
       streak = 0
+      lossStreak += 1
+      if (lossStreak >= 2) {
+        milestones.push({ kind: "loss-streak", emoji: "📉", label: `${lossStreak}-loss streak` })
+      }
       if (typeof me?.knockoutTurn === "number" && me.knockoutTurn <= 6) {
         milestones.push({ kind: "knockout", label: `Knocked out turn ${me.knockoutTurn}`, detail: cmdr })
       }

--- a/src/components/prototypes/historyTimeline/timeline.ts
+++ b/src/components/prototypes/historyTimeline/timeline.ts
@@ -11,6 +11,7 @@ export type MilestoneKind =
   | "streak"
   | "fast-win"
   | "wincon"
+  | "knockout"
 
 export interface Milestone {
   kind: MilestoneKind
@@ -98,6 +99,9 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       }
     } else {
       streak = 0
+      if (typeof me?.knockoutTurn === "number" && me.knockoutTurn <= 6) {
+        milestones.push({ kind: "knockout", label: `Knocked out turn ${me.knockoutTurn}`, detail: cmdr })
+      }
     }
 
     return { game, me, won, date: new Date(game.playedAt), careerIndex, winNumber, milestones }
@@ -159,6 +163,46 @@ export function groupByMonth(events: TimelineEvent[]): MonthChapter[] {
   }
 
   return chapters
+}
+
+// ── Pod grouping ─────────────────────────────────────────────────────────────
+
+export interface PodBlock {
+  key: string
+  label: string
+  events: TimelineEvent[]
+  games: number
+  wins: number
+  latest: number
+}
+
+function podKeyForGame(game: Game): string | null {
+  const names = game.players.map((p) => p.displayName?.trim()).filter(Boolean) as string[]
+  if (names.length !== game.players.length || names.length === 0) return null
+  return [...names].sort((a, b) => a.localeCompare(b)).join("|||")
+}
+
+/** Group events by the exact set of players at the table (a "pod"). Games where
+ *  not every seat is named are dropped, matching the existing History pods view. */
+export function groupIntoPods(events: TimelineEvent[]): PodBlock[] {
+  const map = new Map<string, PodBlock>()
+  for (const ev of events) {
+    const key = podKeyForGame(ev.game)
+    if (!key) continue
+    let block = map.get(key)
+    if (!block) {
+      const names = [...new Set(ev.game.players.map((p) => p.displayName!.trim()))].sort((a, b) =>
+        a.localeCompare(b)
+      )
+      block = { key, label: names.join(", "), events: [], games: 0, wins: 0, latest: 0 }
+      map.set(key, block)
+    }
+    block.events.push(ev)
+    block.games += 1
+    if (ev.won) block.wins += 1
+    block.latest = Math.max(block.latest, ev.date.getTime())
+  }
+  return Array.from(map.values()).sort((a, b) => b.latest - a.latest)
 }
 
 // ── Formatting helpers ───────────────────────────────────────────────────────

--- a/src/components/prototypes/historyTimeline/timeline.ts
+++ b/src/components/prototypes/historyTimeline/timeline.ts
@@ -1,0 +1,167 @@
+import type { Game, MtgColor, Player } from "@/types"
+
+// ── Milestones ───────────────────────────────────────────────────────────────
+
+export type MilestoneKind =
+  | "first-game"
+  | "first-win"
+  | "milestone-game"
+  | "streak"
+  | "debut"
+  | "fast-win"
+
+export interface Milestone {
+  kind: MilestoneKind
+  label: string
+}
+
+export interface TimelineEvent {
+  game: Game
+  me?: Player
+  won: boolean
+  date: Date
+  /** 1-based index of this game in the user's career (chronological). */
+  careerIndex: number
+  milestones: Milestone[]
+}
+
+const GAME_COUNT_MILESTONES = new Set([1, 5, 10, 25, 50, 75, 100, 150, 200, 250, 500])
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"]
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}
+
+/**
+ * Walk games chronologically to derive career milestones (streaks, debuts,
+ * firsts), then return events newest-first for display.
+ */
+export function buildTimeline(games: Game[]): TimelineEvent[] {
+  const chrono = [...games].sort(
+    (a, b) => new Date(a.playedAt).getTime() - new Date(b.playedAt).getTime()
+  )
+
+  const seenCommanders = new Set<string>()
+  let hasWon = false
+  let streak = 0
+
+  const events: TimelineEvent[] = chrono.map((game, i) => {
+    const me = game.players.find((p) => p.isMe)
+    const won = !!me && game.winnerId === me.id
+    const careerIndex = i + 1
+    const milestones: Milestone[] = []
+
+    if (careerIndex === 1) {
+      milestones.push({ kind: "first-game", label: "First game logged" })
+    }
+    if (GAME_COUNT_MILESTONES.has(careerIndex) && careerIndex !== 1) {
+      milestones.push({ kind: "milestone-game", label: `${ordinal(careerIndex)} game` })
+    }
+
+    const cmdr = me?.commanderName
+    if (cmdr && !seenCommanders.has(cmdr)) {
+      if (seenCommanders.size > 0) {
+        milestones.push({ kind: "debut", label: `Debut: ${cmdr.split(",")[0]}` })
+      }
+      seenCommanders.add(cmdr)
+    }
+
+    if (won) {
+      if (!hasWon) {
+        hasWon = true
+        milestones.push({ kind: "first-win", label: "First win" })
+      }
+      streak += 1
+      if (streak >= 2) {
+        milestones.push({ kind: "streak", label: `${streak}-game win streak` })
+      }
+      if (game.winTurn && game.winTurn <= 5) {
+        milestones.push({ kind: "fast-win", label: `Fast win — turn ${game.winTurn}` })
+      }
+    } else {
+      streak = 0
+    }
+
+    return { game, me, won, date: new Date(game.playedAt), careerIndex, milestones }
+  })
+
+  return events.reverse()
+}
+
+// ── Month grouping (over already newest-first events) ────────────────────────
+
+export interface MonthChapter {
+  key: string
+  label: string
+  events: TimelineEvent[]
+  games: number
+  wins: number
+  winRate: number
+  topCommander?: string
+}
+
+export function groupByMonth(events: TimelineEvent[]): MonthChapter[] {
+  const chapters: MonthChapter[] = []
+  let current: MonthChapter | null = null
+
+  for (const ev of events) {
+    const d = ev.date
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`
+    if (!current || current.key !== key) {
+      current = {
+        key,
+        label: d.toLocaleDateString(undefined, { month: "long", year: "numeric" }),
+        events: [],
+        games: 0,
+        wins: 0,
+        winRate: 0,
+      }
+      chapters.push(current)
+    }
+    current.events.push(ev)
+  }
+
+  for (const c of chapters) {
+    c.games = c.events.length
+    c.wins = c.events.filter((e) => e.won).length
+    c.winRate = c.games ? c.wins / c.games : 0
+    const tally = new Map<string, number>()
+    for (const e of c.events) {
+      const name = e.me?.commanderName
+      if (name) tally.set(name, (tally.get(name) ?? 0) + 1)
+    }
+    let best: string | undefined
+    let bestCount = 0
+    for (const [name, count] of tally) {
+      if (count > bestCount) {
+        best = name
+        bestCount = count
+      }
+    }
+    c.topCommander = best
+  }
+
+  return chapters
+}
+
+// ── Formatting helpers ───────────────────────────────────────────────────────
+
+export function colorsOf(me?: Player): MtgColor[] {
+  return (me?.commanderColorIdentity ?? []) as MtgColor[]
+}
+
+export function opponentsOf(game: Game): string[] {
+  return game.players
+    .filter((p) => !p.isMe)
+    .map((p) => p.commanderName.split(" // ")[0].split(",")[0])
+}
+
+export function shortCommander(name?: string): string {
+  if (!name) return "Unknown"
+  return name.split(" // ")[0]
+}
+
+export function dayLabel(d: Date): string {
+  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })
+}

--- a/src/components/prototypes/historyTimeline/timeline.ts
+++ b/src/components/prototypes/historyTimeline/timeline.ts
@@ -30,16 +30,16 @@ export interface Milestone {
   label: string
   /** Supporting context, e.g. "Krenko, Mob Boss". */
   detail?: string
-  /** Optional emoji shown instead of the kind's lucide icon. */
-  emoji?: string
+  /** Optional icon-name override (otherwise the kind's default icon is used). */
+  iconName?: string
 }
 
 /** Per-commander play-count tiers — "veteran status" for a deck you keep bringing. */
-const VETERAN_TIERS: { n: number; emoji: string; detail: string }[] = [
-  { n: 10, emoji: "🧒", detail: "Getting comfortable" },
-  { n: 20, emoji: "🧑", detail: "Seasoned pilot" },
-  { n: 50, emoji: "🧓", detail: "Grizzled veteran" },
-  { n: 100, emoji: "🧙", detail: "True master" },
+const VETERAN_TIERS: { n: number; iconName: string; detail: string }[] = [
+  { n: 10, iconName: "Sprout", detail: "Getting comfortable" },
+  { n: 20, iconName: "Star", detail: "Seasoned pilot" },
+  { n: 50, iconName: "Medal", detail: "Grizzled veteran" },
+  { n: 100, iconName: "Gem", detail: "True master" },
 ]
 
 const COLOR_NAMES: Record<MtgColor, string> = {
@@ -143,18 +143,18 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
     }
 
     if (me?.commanderName && playCount === 1 && careerIndex > 1) {
-      milestones.push({ kind: "debut", emoji: "👶", label: `${cmdr} debut`, detail: "First time piloting this deck" })
+      milestones.push({ kind: "debut", label: `${cmdr} debut`, detail: "First time piloting this deck" })
     }
     const tier = VETERAN_TIERS.find((t) => t.n === playCount)
     if (tier && me?.commanderName) {
-      milestones.push({ kind: "veteran", emoji: tier.emoji, label: `${ordinal(playCount)} game with ${cmdr}`, detail: tier.detail })
+      milestones.push({ kind: "veteran", iconName: tier.iconName, label: `${ordinal(playCount)} game with ${cmdr}`, detail: tier.detail })
     }
 
     // New rival — first ever game against a newly-seen opponent.
     if (careerIndex > 1) {
       const newcomer = opponents.find((o) => !seenOpponents.has(o.commanderName))
       if (newcomer) {
-        milestones.push({ kind: "new-rival", emoji: "🤝", label: "New rival", detail: shortCommander(newcomer.commanderName) })
+        milestones.push({ kind: "new-rival", label: "New rival", detail: shortCommander(newcomer.commanderName) })
       }
     }
     for (const o of opponents) seenOpponents.add(o.commanderName)
@@ -177,7 +177,7 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
         milestones.push({ kind: "streak", label: `${streak}-win streak` })
       }
       if (slump >= 3) {
-        milestones.push({ kind: "comeback", emoji: "♻️", label: "Comeback win", detail: `Snapped a ${slump}-loss slump` })
+        milestones.push({ kind: "comeback", label: "Comeback win", detail: `Snapped a ${slump}-loss slump` })
       }
 
       // Nemesis — beat an opponent who has beaten you 3+ times.
@@ -191,7 +191,7 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
         }
       }
       if (nemesis) {
-        milestones.push({ kind: "nemesis", emoji: "🦸", label: "Nemesis slain", detail: `${shortCommander(nemesis)} had beaten you ${nemesisCount}×` })
+        milestones.push({ kind: "nemesis", label: "Nemesis slain", detail: `${shortCommander(nemesis)} had beaten you ${nemesisCount}×` })
       }
 
       // Color pioneer — first win in a brand-new color identity.
@@ -199,27 +199,27 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       const ck = colorIdentityKey(identity)
       if (!wonColorIdentities.has(ck)) {
         wonColorIdentities.add(ck)
-        milestones.push({ kind: "color-pioneer", emoji: "🌈", label: `First win in ${colorIdentityLabel(identity)}`, detail: "New colors on the board" })
+        milestones.push({ kind: "color-pioneer", label: `First win in ${colorIdentityLabel(identity)}`, detail: "New colors on the board" })
       }
 
       if (me && me.seatPosition >= 3) {
-        milestones.push({ kind: "tough-seat", emoji: "🎯", label: `Won from seat ${me.seatPosition}`, detail: "Back-of-the-table win" })
+        milestones.push({ kind: "tough-seat", label: `Won from seat ${me.seatPosition}`, detail: "Back-of-the-table win" })
       }
       const beatFastMana =
         !me?.fastMana?.hasFastMana &&
         game.players.some((p) => !p.isMe && p.fastMana?.hasFastMana)
       if (beatFastMana) {
-        milestones.push({ kind: "underdog", emoji: "🐢", label: "Beat a fast-mana start", detail: "No fast mana of your own" })
+        milestones.push({ kind: "underdog", label: "Beat a fast-mana start", detail: "No fast mana of your own" })
       }
       if (game.winTurn && game.winTurn <= 5) {
         milestones.push({ kind: "fast-win", label: `Turn-${game.winTurn} kill`, detail: cmdr })
       }
       if (game.winTurn && game.winTurn >= 12) {
-        milestones.push({ kind: "slow-burn", emoji: "🐉", label: `Turn-${game.winTurn} grind`, detail: cmdr })
+        milestones.push({ kind: "slow-burn", label: `Turn-${game.winTurn} grind`, detail: cmdr })
       }
       // Bracket buster — win meaningfully above your usual power level.
       if (game.bracket && priorBracketAvg !== null && bracketCount >= 3 && game.bracket > priorBracketAvg + 0.75) {
-        milestones.push({ kind: "bracket-buster", emoji: "🎰", label: "Bracket buster", detail: `Won up at bracket ${game.bracket}` })
+        milestones.push({ kind: "bracket-buster", label: "Bracket buster", detail: `Won up at bracket ${game.bracket}` })
       }
       if (game.keyWinconCards && game.keyWinconCards.length > 0) {
         milestones.push({ kind: "wincon", label: `Closed with ${game.keyWinconCards[0]}` })
@@ -228,7 +228,7 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       streak = 0
       lossStreak += 1
       if (lossStreak >= 2) {
-        milestones.push({ kind: "loss-streak", emoji: "📉", label: `${lossStreak}-loss streak` })
+        milestones.push({ kind: "loss-streak", label: `${lossStreak}-loss streak` })
       }
       if (typeof me?.knockoutTurn === "number" && me.knockoutTurn <= 6) {
         milestones.push({ kind: "knockout", label: `Knocked out turn ${me.knockoutTurn}`, detail: cmdr })
@@ -243,7 +243,7 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
     const monthKey = `${date.getFullYear()}-${date.getMonth()}`
     const ma = monthAgg.get(monthKey)
     if (ma && ma.lastId === game.id && ma.count >= 3 && ma.wins === ma.count) {
-      milestones.push({ kind: "flawless-month", emoji: "🏆", label: "Flawless month", detail: `${ma.count}–0 in ${ma.label}` })
+      milestones.push({ kind: "flawless-month", label: "Flawless month", detail: `${ma.count}–0 in ${ma.label}` })
     }
 
     if (game.bracket) {

--- a/src/components/prototypes/historyTimeline/timeline.ts
+++ b/src/components/prototypes/historyTimeline/timeline.ts
@@ -4,15 +4,20 @@ import type { Game, MtgColor, Player } from "@/types"
 
 export type MilestoneKind =
   | "first-game"
-  | "first-win"
   | "milestone-game"
-  | "streak"
   | "debut"
+  | "first-win"
+  | "win"
+  | "streak"
   | "fast-win"
+  | "wincon"
 
 export interface Milestone {
   kind: MilestoneKind
+  /** Headline, e.g. "5th career win". */
   label: string
+  /** Supporting context, e.g. "Krenko, Mob Boss". */
+  detail?: string
 }
 
 export interface TimelineEvent {
@@ -22,10 +27,13 @@ export interface TimelineEvent {
   date: Date
   /** 1-based index of this game in the user's career (chronological). */
   careerIndex: number
+  /** 1-based win number, or null for a loss. */
+  winNumber: number | null
   milestones: Milestone[]
 }
 
-const GAME_COUNT_MILESTONES = new Set([1, 5, 10, 25, 50, 75, 100, 150, 200, 250, 500])
+const GAME_LANDMARKS = new Set([10, 25, 50, 75, 100, 150, 200, 250, 500])
+const WIN_LANDMARKS = new Set([5, 10, 25, 50, 75, 100, 150, 200])
 
 function ordinal(n: number): string {
   const s = ["th", "st", "nd", "rd"]
@@ -34,8 +42,9 @@ function ordinal(n: number): string {
 }
 
 /**
- * Walk games chronologically to derive career milestones (streaks, debuts,
- * firsts), then return events newest-first for display.
+ * Walk games chronologically to derive career milestones (firsts, win/game
+ * landmarks, streaks, debuts, fast kills, signature wincons), then return events
+ * newest-first for display.
  */
 export function buildTimeline(games: Game[]): TimelineEvent[] {
   const chrono = [...games].sort(
@@ -43,47 +52,55 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
   )
 
   const seenCommanders = new Set<string>()
-  let hasWon = false
+  let winCount = 0
   let streak = 0
 
   const events: TimelineEvent[] = chrono.map((game, i) => {
     const me = game.players.find((p) => p.isMe)
     const won = !!me && game.winnerId === me.id
     const careerIndex = i + 1
+    const cmdr = shortCommander(me?.commanderName)
     const milestones: Milestone[] = []
 
     if (careerIndex === 1) {
-      milestones.push({ kind: "first-game", label: "First game logged" })
-    }
-    if (GAME_COUNT_MILESTONES.has(careerIndex) && careerIndex !== 1) {
-      milestones.push({ kind: "milestone-game", label: `${ordinal(careerIndex)} game` })
+      milestones.push({ kind: "first-game", label: "First game logged", detail: cmdr })
+    } else if (GAME_LANDMARKS.has(careerIndex)) {
+      milestones.push({ kind: "milestone-game", label: `${ordinal(careerIndex)} game played`, detail: cmdr })
     }
 
-    const cmdr = me?.commanderName
-    if (cmdr && !seenCommanders.has(cmdr)) {
+    if (me?.commanderName && !seenCommanders.has(me.commanderName)) {
       if (seenCommanders.size > 0) {
-        milestones.push({ kind: "debut", label: `Debut: ${cmdr.split(",")[0]}` })
+        milestones.push({ kind: "debut", label: `${cmdr} debut`, detail: "First time piloting this deck" })
       }
-      seenCommanders.add(cmdr)
+      seenCommanders.add(me.commanderName)
     }
 
+    let winNumber: number | null = null
     if (won) {
-      if (!hasWon) {
-        hasWon = true
-        milestones.push({ kind: "first-win", label: "First win" })
-      }
+      winCount += 1
+      winNumber = winCount
       streak += 1
+
+      if (winCount === 1) {
+        milestones.push({ kind: "first-win", label: "First win", detail: cmdr })
+      } else if (WIN_LANDMARKS.has(winCount)) {
+        milestones.push({ kind: "win", label: `${ordinal(winCount)} career win`, detail: cmdr })
+      }
+
       if (streak >= 2) {
-        milestones.push({ kind: "streak", label: `${streak}-game win streak` })
+        milestones.push({ kind: "streak", label: `${streak}-win streak` })
       }
       if (game.winTurn && game.winTurn <= 5) {
-        milestones.push({ kind: "fast-win", label: `Fast win — turn ${game.winTurn}` })
+        milestones.push({ kind: "fast-win", label: `Turn-${game.winTurn} kill`, detail: cmdr })
+      }
+      if (game.keyWinconCards && game.keyWinconCards.length > 0) {
+        milestones.push({ kind: "wincon", label: `Closed with ${game.keyWinconCards[0]}` })
       }
     } else {
       streak = 0
     }
 
-    return { game, me, won, date: new Date(game.playedAt), careerIndex, milestones }
+    return { game, me, won, date: new Date(game.playedAt), careerIndex, winNumber, milestones }
   })
 
   return events.reverse()
@@ -99,6 +116,7 @@ export interface MonthChapter {
   wins: number
   winRate: number
   topCommander?: string
+  topCommanderGames: number
 }
 
 export function groupByMonth(events: TimelineEvent[]): MonthChapter[] {
@@ -116,6 +134,7 @@ export function groupByMonth(events: TimelineEvent[]): MonthChapter[] {
         games: 0,
         wins: 0,
         winRate: 0,
+        topCommanderGames: 0,
       }
       chapters.push(current)
     }
@@ -131,15 +150,12 @@ export function groupByMonth(events: TimelineEvent[]): MonthChapter[] {
       const name = e.me?.commanderName
       if (name) tally.set(name, (tally.get(name) ?? 0) + 1)
     }
-    let best: string | undefined
-    let bestCount = 0
     for (const [name, count] of tally) {
-      if (count > bestCount) {
-        best = name
-        bestCount = count
+      if (count > c.topCommanderGames) {
+        c.topCommander = name
+        c.topCommanderGames = count
       }
     }
-    c.topCommander = best
   }
 
   return chapters

--- a/src/components/prototypes/historyTimeline/timeline.ts
+++ b/src/components/prototypes/historyTimeline/timeline.ts
@@ -11,9 +11,16 @@ export type MilestoneKind =
   | "win"
   | "streak"
   | "fast-win"
+  | "slow-burn"
   | "wincon"
   | "tough-seat"
   | "underdog"
+  | "nemesis"
+  | "new-rival"
+  | "comeback"
+  | "color-pioneer"
+  | "bracket-buster"
+  | "flawless-month"
   | "knockout"
   | "loss-streak"
 
@@ -34,6 +41,27 @@ const VETERAN_TIERS: { n: number; emoji: string; detail: string }[] = [
   { n: 50, emoji: "🧓", detail: "Grizzled veteran" },
   { n: 100, emoji: "🧙", detail: "True master" },
 ]
+
+const COLOR_NAMES: Record<MtgColor, string> = {
+  W: "White",
+  U: "Blue",
+  B: "Black",
+  R: "Red",
+  G: "Green",
+}
+const WUBRG: MtgColor[] = ["W", "U", "B", "R", "G"]
+
+function colorIdentityKey(colors: MtgColor[]): string {
+  if (colors.length === 0) return "C"
+  return WUBRG.filter((c) => colors.includes(c)).join("")
+}
+
+function colorIdentityLabel(colors: MtgColor[]): string {
+  if (colors.length === 0) return "Colorless"
+  if (colors.length === 5) return "5-Color"
+  if (colors.length === 1) return `Mono-${COLOR_NAMES[colors[0]]}`
+  return WUBRG.filter((c) => colors.includes(c)).join("")
+}
 
 export interface TimelineEvent {
   game: Game
@@ -66,16 +94,43 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
     (a, b) => new Date(a.playedAt).getTime() - new Date(b.playedAt).getTime()
   )
 
+  // Per-month aggregate (chronological, so lastId ends up being the closing game).
+  const monthAgg = new Map<string, { count: number; wins: number; lastId: string; label: string }>()
+  for (const g of chrono) {
+    const d = new Date(g.playedAt)
+    const key = `${d.getFullYear()}-${d.getMonth()}`
+    const me = g.players.find((p) => p.isMe)
+    const won = !!me && g.winnerId === me.id
+    const cur = monthAgg.get(key) ?? {
+      count: 0,
+      wins: 0,
+      lastId: g.id,
+      label: d.toLocaleDateString(undefined, { month: "long" }),
+    }
+    cur.count += 1
+    if (won) cur.wins += 1
+    cur.lastId = g.id
+    monthAgg.set(key, cur)
+  }
+
   const commanderPlays = new Map<string, number>()
+  const beatenByCount = new Map<string, number>() // opponent commander → times they've beaten me
+  const seenOpponents = new Set<string>()
+  const wonColorIdentities = new Set<string>()
   let winCount = 0
   let streak = 0
   let lossStreak = 0
+  let bracketSum = 0
+  let bracketCount = 0
 
   const events: TimelineEvent[] = chrono.map((game, i) => {
     const me = game.players.find((p) => p.isMe)
     const won = !!me && game.winnerId === me.id
     const careerIndex = i + 1
     const cmdr = shortCommander(me?.commanderName)
+    const date = new Date(game.playedAt)
+    const opponents = game.players.filter((p) => !p.isMe)
+    const priorBracketAvg = bracketCount > 0 ? bracketSum / bracketCount : null
     const milestones: Milestone[] = []
 
     const playCount = (commanderPlays.get(me?.commanderName ?? "") ?? 0) + 1
@@ -95,8 +150,18 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       milestones.push({ kind: "veteran", emoji: tier.emoji, label: `${ordinal(playCount)} game with ${cmdr}`, detail: tier.detail })
     }
 
+    // New rival — first ever game against a newly-seen opponent.
+    if (careerIndex > 1) {
+      const newcomer = opponents.find((o) => !seenOpponents.has(o.commanderName))
+      if (newcomer) {
+        milestones.push({ kind: "new-rival", emoji: "🤝", label: "New rival", detail: shortCommander(newcomer.commanderName) })
+      }
+    }
+    for (const o of opponents) seenOpponents.add(o.commanderName)
+
     let winNumber: number | null = null
     if (won) {
+      const slump = lossStreak // capture before reset
       winCount += 1
       winNumber = winCount
       streak += 1
@@ -111,6 +176,32 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       if (streak >= 2) {
         milestones.push({ kind: "streak", label: `${streak}-win streak` })
       }
+      if (slump >= 3) {
+        milestones.push({ kind: "comeback", emoji: "♻️", label: "Comeback win", detail: `Snapped a ${slump}-loss slump` })
+      }
+
+      // Nemesis — beat an opponent who has beaten you 3+ times.
+      let nemesis: string | undefined
+      let nemesisCount = 0
+      for (const o of opponents) {
+        const c = beatenByCount.get(o.commanderName) ?? 0
+        if (c >= 3 && c > nemesisCount) {
+          nemesis = o.commanderName
+          nemesisCount = c
+        }
+      }
+      if (nemesis) {
+        milestones.push({ kind: "nemesis", emoji: "🦸", label: "Nemesis slain", detail: `${shortCommander(nemesis)} had beaten you ${nemesisCount}×` })
+      }
+
+      // Color pioneer — first win in a brand-new color identity.
+      const identity = colorsOf(me)
+      const ck = colorIdentityKey(identity)
+      if (!wonColorIdentities.has(ck)) {
+        wonColorIdentities.add(ck)
+        milestones.push({ kind: "color-pioneer", emoji: "🌈", label: `First win in ${colorIdentityLabel(identity)}`, detail: "New colors on the board" })
+      }
+
       if (me && me.seatPosition >= 3) {
         milestones.push({ kind: "tough-seat", emoji: "🎯", label: `Won from seat ${me.seatPosition}`, detail: "Back-of-the-table win" })
       }
@@ -122,6 +213,13 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       }
       if (game.winTurn && game.winTurn <= 5) {
         milestones.push({ kind: "fast-win", label: `Turn-${game.winTurn} kill`, detail: cmdr })
+      }
+      if (game.winTurn && game.winTurn >= 12) {
+        milestones.push({ kind: "slow-burn", emoji: "🐉", label: `Turn-${game.winTurn} grind`, detail: cmdr })
+      }
+      // Bracket buster — win meaningfully above your usual power level.
+      if (game.bracket && priorBracketAvg !== null && bracketCount >= 3 && game.bracket > priorBracketAvg + 0.75) {
+        milestones.push({ kind: "bracket-buster", emoji: "🎰", label: "Bracket buster", detail: `Won up at bracket ${game.bracket}` })
       }
       if (game.keyWinconCards && game.keyWinconCards.length > 0) {
         milestones.push({ kind: "wincon", label: `Closed with ${game.keyWinconCards[0]}` })
@@ -135,9 +233,25 @@ export function buildTimeline(games: Game[]): TimelineEvent[] {
       if (typeof me?.knockoutTurn === "number" && me.knockoutTurn <= 6) {
         milestones.push({ kind: "knockout", label: `Knocked out turn ${me.knockoutTurn}`, detail: cmdr })
       }
+      const winner = game.players.find((p) => p.id === game.winnerId)
+      if (winner && !winner.isMe) {
+        beatenByCount.set(winner.commanderName, (beatenByCount.get(winner.commanderName) ?? 0) + 1)
+      }
     }
 
-    return { game, me, won, date: new Date(game.playedAt), careerIndex, winNumber, milestones }
+    // Flawless month — closing game of a calendar month that went undefeated (≥3 games).
+    const monthKey = `${date.getFullYear()}-${date.getMonth()}`
+    const ma = monthAgg.get(monthKey)
+    if (ma && ma.lastId === game.id && ma.count >= 3 && ma.wins === ma.count) {
+      milestones.push({ kind: "flawless-month", emoji: "🏆", label: "Flawless month", detail: `${ma.count}–0 in ${ma.label}` })
+    }
+
+    if (game.bracket) {
+      bracketSum += game.bracket
+      bracketCount += 1
+    }
+
+    return { game, me, won, date, careerIndex, winNumber, milestones }
   })
 
   return events.reverse()

--- a/src/pages/PrototypesPage.tsx
+++ b/src/pages/PrototypesPage.tsx
@@ -50,13 +50,13 @@ export function PrototypesPage({ games }: PrototypesPageProps) {
   return (
     <div className="space-y-6">
       <div>
-        <div className="flex items-center gap-2">
-          <h1 className="text-xl font-semibold tracking-tight">History · Timeline</h1>
-          <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+        <div className="flex items-center gap-2.5">
+          <h1 className="text-2xl font-semibold tracking-tight">History · Timeline</h1>
+          <span className="rounded-full bg-amber-500/15 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
             Prototype
           </span>
         </div>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1.5 text-base text-muted-foreground">
           Three takes on reimagining the History page as a personal timeline.
         </p>
       </div>
@@ -80,8 +80,8 @@ export function PrototypesPage({ games }: PrototypesPageProps) {
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm text-muted-foreground">{variant.tagline}</p>
-        <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+        <p className="text-base text-muted-foreground">{variant.tagline}</p>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
           <input
             type="checkbox"
             checked={useSample}

--- a/src/pages/PrototypesPage.tsx
+++ b/src/pages/PrototypesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { cn } from "@/lib/utils"
 import type { Game } from "@/types"
 import { VariantJourney } from "@/components/prototypes/historyTimeline/VariantJourney"
@@ -6,11 +6,17 @@ import { VariantChapters } from "@/components/prototypes/historyTimeline/Variant
 import { VariantFeed } from "@/components/prototypes/historyTimeline/VariantFeed"
 import { buildSampleGames } from "@/components/prototypes/historyTimeline/sampleGames"
 
+interface VariantContext {
+  games: Game[]
+  onEditGame?: (id: string) => void
+  onDeleteGame?: (id: string) => void
+}
+
 interface Variant {
   id: string
   name: string
   tagline: string
-  render: (games: Game[]) => React.ReactNode
+  render: (ctx: VariantContext) => React.ReactNode
 }
 
 const VARIANTS: Variant[] = [
@@ -18,34 +24,47 @@ const VARIANTS: Variant[] = [
     id: "journey",
     name: "Journey",
     tagline: "A vertical spine of your whole career — every game a node, wins lit up.",
-    render: (games) => <VariantJourney games={games} />,
+    render: ({ games, onEditGame, onDeleteGame }) => (
+      <VariantJourney games={games} onEditGame={onEditGame} onDeleteGame={onDeleteGame} />
+    ),
   },
   {
     id: "chapters",
     name: "Chapters",
     tagline: "Your history told month by month, each with its own record and signature deck.",
-    render: (games) => <VariantChapters games={games} />,
+    render: ({ games }) => <VariantChapters games={games} />,
   },
   {
     id: "activity",
     name: "Activity",
     tagline: "A play heatmap and a social-style feed of wins, losses and milestones.",
-    render: (games) => <VariantFeed games={games} />,
+    render: ({ games }) => <VariantFeed games={games} />,
   },
 ]
 
 interface PrototypesPageProps {
   games: Game[]
+  onEditGame?: (id: string) => void
+  onDeleteGame?: (id: string) => void
 }
 
-export function PrototypesPage({ games }: PrototypesPageProps) {
+export function PrototypesPage({ games, onEditGame, onDeleteGame }: PrototypesPageProps) {
   const [active, setActive] = useState(VARIANTS[0].id)
   const hasRealGames = games.length > 0
   const [useSample, setUseSample] = useState(!hasRealGames)
 
-  const sample = useMemo(() => buildSampleGames(), [])
+  // Local copy so delete works as a live demo against sample data.
+  const [sample, setSample] = useState<Game[]>(() => buildSampleGames())
   const data = useSample ? sample : games
   const variant = VARIANTS.find((v) => v.id === active) ?? VARIANTS[0]
+
+  const ctx: VariantContext = useSample
+    ? {
+        games: sample,
+        onEditGame: () => {},
+        onDeleteGame: (id) => setSample((s) => s.filter((g) => g.id !== id)),
+      }
+    : { games: data, onEditGame, onDeleteGame }
 
   return (
     <div className="space-y-6">
@@ -93,7 +112,7 @@ export function PrototypesPage({ games }: PrototypesPageProps) {
         </label>
       </div>
 
-      <div>{variant.render(data)}</div>
+      <div>{variant.render(ctx)}</div>
     </div>
   )
 }

--- a/src/pages/PrototypesPage.tsx
+++ b/src/pages/PrototypesPage.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from "react"
+import { cn } from "@/lib/utils"
+import type { Game } from "@/types"
+import { VariantJourney } from "@/components/prototypes/historyTimeline/VariantJourney"
+import { VariantChapters } from "@/components/prototypes/historyTimeline/VariantChapters"
+import { VariantFeed } from "@/components/prototypes/historyTimeline/VariantFeed"
+import { buildSampleGames } from "@/components/prototypes/historyTimeline/sampleGames"
+
+interface Variant {
+  id: string
+  name: string
+  tagline: string
+  render: (games: Game[]) => React.ReactNode
+}
+
+const VARIANTS: Variant[] = [
+  {
+    id: "journey",
+    name: "Journey",
+    tagline: "A vertical spine of your whole career — every game a node, wins lit up.",
+    render: (games) => <VariantJourney games={games} />,
+  },
+  {
+    id: "chapters",
+    name: "Chapters",
+    tagline: "Your history told month by month, each with its own record and signature deck.",
+    render: (games) => <VariantChapters games={games} />,
+  },
+  {
+    id: "activity",
+    name: "Activity",
+    tagline: "A play heatmap and a social-style feed of wins, losses and milestones.",
+    render: (games) => <VariantFeed games={games} />,
+  },
+]
+
+interface PrototypesPageProps {
+  games: Game[]
+}
+
+export function PrototypesPage({ games }: PrototypesPageProps) {
+  const [active, setActive] = useState(VARIANTS[0].id)
+  const hasRealGames = games.length > 0
+  const [useSample, setUseSample] = useState(!hasRealGames)
+
+  const sample = useMemo(() => buildSampleGames(), [])
+  const data = useSample ? sample : games
+  const variant = VARIANTS.find((v) => v.id === active) ?? VARIANTS[0]
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl font-semibold tracking-tight">History · Timeline</h1>
+          <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+            Prototype
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Three takes on reimagining the History page as a personal timeline.
+        </p>
+      </div>
+
+      {/* Variant switcher */}
+      <div className="inline-flex rounded-md border border-input p-0.5 gap-0.5">
+        {VARIANTS.map((v) => (
+          <button
+            key={v.id}
+            onClick={() => setActive(v.id)}
+            className={cn(
+              "h-9 px-4 rounded-[8px] text-sm font-medium transition-colors",
+              active === v.id
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {v.name}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">{variant.tagline}</p>
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={useSample}
+            onChange={(e) => setUseSample(e.target.checked)}
+            className="h-3.5 w-3.5 accent-[hsl(var(--primary))]"
+          />
+          Sample data
+          {!hasRealGames && <span className="opacity-60">(no real games yet)</span>}
+        </label>
+      </div>
+
+      <div>{variant.render(data)}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
Reimagines the History page as a personal **timeline of the user**, behind an isolated `/prototypes/history` harness with a variant switcher. Nothing in the production UI changes except the added route.

## Three variants

- **Journey** — a single vertical "metro line" spine, newest-first. Every game is a node (wins lit up), with milestones blooming as chips beside it.
- **Chapters** — your career told month by month. Each chapter has a narrative header (W–L record, win-rate bar, signature deck), then that month's games with milestone strips between them.
- **Activity** — a GitHub-style contribution heatmap of table time, followed by a social-style feed ("Won with Krenko on turn 6 vs Edgar · Najeela") with milestone callouts.

## Shared engine

`timeline.ts` walks games chronologically to derive career milestones — first game, first win, win streaks, deck debuts, fast wins, and game-count landmarks (5th, 10th, 25th…) — then displays newest-first.

## Demoable without data

A deterministic sample career (`sampleGames.ts`) auto-loads when there are no logged games, with a **Sample data** toggle to switch to real games. The sample is crafted so a debut, first win, and a 3-game streak all surface.

## Notes

- Reachable at `/prototypes/history` (intentionally not in the bottom nav).
- `npm run build` ✓ and `npm run lint` ✓.
- All new code lives under `src/components/prototypes/`; only the added route touches existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVfTbBR5NAzPEWssFn5gPv)_