### PR TITLE
chore: keep the free-tier Supabase project from auto-pausing

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,31 @@
+name: Supabase Keepalive
+
+on:
+  # Mondays and Thursdays — a 3–4 day cadence, so one missed run still lands
+  # well inside Supabase's 7-day inactivity window. Off-the-hour minute because
+  # scheduled runs at :00 are the most likely to be delayed.
+  schedule:
+    - cron: "17 6 * * 1,4"
+  workflow_dispatch:
+
+concurrency:
+  group: supabase-keepalive
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ping Supabase
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          KEEPALIVE_SOURCE: github-actions
+        run: node scripts/keepalive_ping.mjs

--- a/scripts/keepalive_ping.mjs
+++ b/scripts/keepalive_ping.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Keeps the free-tier Supabase project from auto-pausing.
+ *
+ * Calls public.keepalive_ping() (see supabase/migrations/006_keepalive.sql),
+ * which performs a real Postgres write and returns the previous ping time.
+ * Exits non-zero if the gap since the previous ping exceeded the pause window,
+ * which means the schedule stopped running and needs attention.
+ *
+ * Requires env vars:
+ *   SUPABASE_URL              - e.g. https://xxx.supabase.co
+ *   SUPABASE_ANON_KEY         - the anon/public key
+ *   KEEPALIVE_SOURCE          - (optional) label stored with the ping
+ *   KEEPALIVE_MAX_GAP_DAYS    - (optional) defaults to 7
+ *
+ * Usage:
+ *   node scripts/keepalive_ping.mjs
+ *
+ * Exit 0 = project pinged and the schedule is healthy, Exit 1 = needs a look.
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY
+const SOURCE = process.env.KEEPALIVE_SOURCE || "github-actions"
+const MAX_GAP_DAYS = Number(process.env.KEEPALIVE_MAX_GAP_DAYS || 7)
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.error("❌ SUPABASE_URL and SUPABASE_ANON_KEY env vars are required.")
+  process.exit(1)
+}
+
+const ATTEMPTS = 3
+
+async function ping() {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/keepalive_ping`, {
+    method: "POST",
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ p_source: SOURCE }),
+  })
+
+  const text = await res.text()
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text.slice(0, 300)}`)
+
+  const rows = JSON.parse(text)
+  const row = Array.isArray(rows) ? rows[0] : rows
+  if (!row?.pinged_at) throw new Error(`Unexpected response: ${text.slice(0, 300)}`)
+  return row
+}
+
+let row
+for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+  try {
+    row = await ping()
+    break
+  } catch (err) {
+    console.error(`Attempt ${attempt}/${ATTEMPTS} failed: ${err.message}`)
+    if (attempt === ATTEMPTS) {
+      console.error(
+        `❌ Keepalive ping failed after ${ATTEMPTS} attempts. If the errors above are ` +
+          `network/5xx rather than a 4xx, the project may already be paused.`
+      )
+      process.exit(1)
+    }
+    await new Promise((r) => setTimeout(r, attempt * 5000))
+  }
+}
+
+const gapDays = (new Date(row.pinged_at) - new Date(row.previous_pinged_at)) / 86_400_000
+
+console.log(`✅ Pinged at ${row.pinged_at} (source: ${SOURCE}, total pings: ${row.total_pings})`)
+console.log(`   Previous ping: ${row.previous_pinged_at} — ${gapDays.toFixed(1)} days ago`)
+
+if (gapDays > MAX_GAP_DAYS) {
+  console.error(
+    `❌ Gap of ${gapDays.toFixed(1)} days exceeds the ${MAX_GAP_DAYS}-day pause window. ` +
+      `The schedule stopped running — check that the keepalive workflow is still enabled.`
+  )
+  process.exit(1)
+}

--- a/supabase/migrations/006_keepalive.sql
+++ b/supabase/migrations/006_keepalive.sql
@@ -1,0 +1,50 @@
+-- ─── Supabase Migration: Keepalive ping ─────────────────────────────────────
+-- Free-tier projects are paused after 7 days with no activity. A scheduled job
+-- calls public.keepalive_ping() to generate a real Postgres write every few
+-- days. Hitting the REST root is NOT enough — PostgREST can answer that without
+-- touching the database.
+
+-- Single-row table recording the most recent ping.
+create table if not exists public.keepalive (
+  id            smallint primary key default 1,
+  last_ping_at  timestamptz not null default now(),
+  source        text not null default 'seed',
+  ping_count    bigint not null default 0,
+  constraint keepalive_single_row check (id = 1)
+);
+
+insert into public.keepalive (id) values (1) on conflict (id) do nothing;
+
+-- RLS on with no policies: anon/authenticated cannot touch the table directly.
+-- All access goes through the security definer function below.
+alter table public.keepalive enable row level security;
+
+-- Records the ping and returns the PREVIOUS ping time so the caller can detect
+-- that the schedule silently stopped running.
+create or replace function public.keepalive_ping(p_source text default null)
+returns table (
+  pinged_at          timestamptz,
+  previous_pinged_at timestamptz,
+  total_pings        bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  prev timestamptz;
+begin
+  select k.last_ping_at into prev from public.keepalive k where k.id = 1;
+
+  return query
+    update public.keepalive k
+       set last_ping_at = now(),
+           source       = coalesce(p_source, 'unknown'),
+           ping_count   = k.ping_count + 1
+     where k.id = 1
+    returning k.last_ping_at, prev, k.ping_count;
+end;
+$$;
+
+revoke all on function public.keepalive_ping(text) from public;
+grant execute on function public.keepalive_ping(text) to anon, authenticated;


### PR DESCRIPTION
Free-tier Supabase projects pause after 7 days without activity. This adds a scheduled ping that generates real database activity.

## How it works

- `supabase/migrations/006_keepalive.sql` — single-row `keepalive` table with RLS on and **no policies**, so anon/authenticated can't touch it directly. Access goes through `public.keepalive_ping()`, a `security definer` function granted to `anon`.
- `scripts/keepalive_ping.mjs` — calls the RPC, 3 attempts with backoff.
- `.github/workflows/keepalive.yml` — Mon/Thu at 06:17 UTC. A 3–4 day cadence, so one missed run still lands well inside the 7-day window.

Two deliberate choices:

**The ping is a write, not a REST-root GET.** PostgREST can answer `/rest/v1/` without touching Postgres, so root pings are the usual way this fails silently.

**The RPC returns the *previous* ping time**, and the script exits non-zero if that gap exceeded 7 days. The real failure mode here isn't a bad ping, it's the schedule quietly stopping — GitHub disables scheduled workflows after 60 days of repo inactivity.

Uses the existing `SUPABASE_URL` / `SUPABASE_ANON_KEY` repo secrets. No new secrets, and no service-role key.

## Verification

Ran the script against the live project before the migration was applied: the anon key authenticated and PostgREST resolved `public.keepalive_ping(p_source)` exactly as the script sends it, failing only because the function doesn't exist yet. Retry and failure paths confirmed. `npm run build` and `npm run lint` pass.

The SQL itself has not been executed — no local Postgres available.

## Before merging

Apply `006_keepalive.sql` in the Supabase SQL editor first, otherwise the first run 404s. Then confirm with `gh workflow run keepalive.yml` once this is on `main` — `schedule` and `workflow_dispatch` both require the workflow to be on the default branch.

Worth adding separately: an external cron service (cron-job.org, UptimeRobot) hitting the same endpoint every 3 days, as a backup immune to GitHub's 60-day auto-disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)